### PR TITLE
Create license info

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+# License
+
+Redistribution and use of the "Common Lisp Cookbook" in its orginal form (HTML) or in 'derived' forms (PDF, Postscript, RTF and so forth) with or without modification, are permitted provided that the following condition is met:
+Redistributions must reproduce the above copyright notice, this condition and the following disclaimer in the document itself and/or other materials provided with the distribution.
+IMPORTANT: This document is provided by the Common Lisp Cookbook Project "as is" and any expressed or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the Common Lisp Cookbook Project be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this documentation, even if advised of the possibility of such damage.
+
+
+LispCookbook GithubGroup addendum: this document is now managed in a modified format.
+
+Copyright ©:
+2015-2017 LispCookbook Github Group
+2002-2007 The Common Lisp Cookbook Project,
+


### PR DESCRIPTION
Port over the License file, which apparently got munched at some point in the migration.

/cc @vindarel @eudoxia0 @LispCookbook/owners 