### PR TITLE
New page Editors support, with an Atom plugin

### DIFF
--- a/editor-support.md
+++ b/editor-support.md
@@ -1,5 +1,5 @@
 ---
-title: Editors support
+title: Editor support
 ---
 
 The editor of choice is still Emacs, but it is not the only one.

--- a/editors-support.md
+++ b/editors-support.md
@@ -1,0 +1,20 @@
+---
+title: Editors support
+---
+
+The editor of choice is still Emacs, but it is not the only one.
+
+## Editors plugins
+
+For an up to date list of plugins for various editors like Emacs, Vim,
+Atom and others, see the
+[Articulate Common Lisp](http://articulate-lisp.com/ides/summary.html)
+page.
+
+## Using Emacs as an IDE
+
+See ["Using Emacs as an IDE"](emacs-ide.html).
+
+## Setting up Emacs on Windows or Mac
+
+See ["Setting up Emacs on Windows or Mac"](windows.html).

--- a/index.md
+++ b/index.md
@@ -29,6 +29,7 @@ The pages here on Github are kept up to date. You can also download a
 # Content
 
 * [License](license.html)
+* [Editors support](editors-support.html)
 * [Strings](strings.html)
 * [Dates and Times](dates_and_times.html)
 * [Hash Tables](hashes.html)
@@ -45,8 +46,6 @@ The pages here on Github are kept up to date. You can also download a
 * [Foreign Function Interfaces](ffi.html)
 * [Threads](process.html)
 * [Defining Systems](systems.html)
-* [Setting up an IDE with Emacs on Windows or Mac OS X](windows.html)
-* [Using Emacs as a Lisp IDE](emacs-ide.html)
 * [Using the Win32 API](win32.html)
 * [Testing](testing.html)
 * [Miscellaneous](misc.html)


### PR DESCRIPTION
which links to the two old pages and
to Articulate CL that references plugins for Vim, Atom and
others. The Atom plugin is newish and great for beginners. Shall we
copy content into this page so it is directly accessible ?

(I also accept some wordsmithing :) )