### PR TITLE
re-write systems.md, use ASDF tutorial, cl-project skeletons

### DIFF
--- a/systems.md
+++ b/systems.md
@@ -21,7 +21,7 @@ _"the Utilities for Implementation- and OS- Portability"_. You can read
 
 ### Loading a System
 
-The most trivial use of ASDF is by calling `(asdf:load-system :foobar)`
+The most trivial use of ASDF is by calling `(asdf:make :foobar)` (or `load-system`)
 to load your library.
 Then you can use it.
 For instance, if it exports a function `some-fun` in its package `foobar`,
@@ -47,7 +47,7 @@ The convention is that an error SHOULD be signalled if tests are unsuccessful.
 The proper way to designate a system in a program is with lower-case
 strings, not symbols, as in:
 
-    (asdf:load-system "foobar")
+    (asdf:make "foobar")
     (asdf:test-system "foobar")
 
 ### Trivial System Definition
@@ -84,10 +84,9 @@ As for contents of that file, they would look like this:
 
 #### Using the system you defined
 
-Assuming your system is installed under the `~/common-lisp/` hierarchy
-or some other filesystem hierarchy already configured for ASDF,
-you can load it with: `(asdf:load-system "foobar")`,
-or shorter `(asdf:make :foobar)`
+Assuming your system is installed under `~/common-lisp/`,
+`~/quicklisp/local-projects/` or some other filesystem hierarchy
+already configured for ASDF, you can load it with: `(asdf:make "foobar")`.
 
 If your Lisp was already started when you created that file,
 you may have to `(asdf:clear-configuration)` to re-process the configuration.

--- a/systems.md
+++ b/systems.md
@@ -2,87 +2,150 @@
 title: Defining Systems
 ---
 
-A **system** is a collection of Lisp files that together constitute an application or a library, and that should therefore be managed as a whole. A **system definition** describes which source files make up the system, what the dependencies among them are, and the order they should be compiled and loaded in. You can think of a system definition as an enhanced version of a Unix makefile, one that uses Lisp objects to define the systems instead of text files. Unfortunately, system definition is one of the areas that the CL ANSI standard does not address, and therefore almost every lisp version has its own version of a defsystem tool; they all have approximately the same functionality, but with slightly different syntax.
+A **system** is a collection of Lisp files that together constitute an application or a library, and that should therefore be managed as a whole. A **system definition** describes which source files make up the system, what the dependencies among them are, and the order they should be compiled and loaded in.
+
+
+## ASDF
+
+[ASDF](https://gitlab.common-lisp.net/asdf/asdf) is the standard build
+system for Common Lisp. It is shipped in most Common Lisp
+implementations. It includes
+[UIOP](https://gitlab.common-lisp.net/asdf/asdf/blob/master/uiop/README.md),
+_"the Utilities for Implementation- and OS- Portability"_. You can read
+[its manual](https://common-lisp.net/project/asdf/asdf.html) and the
+[tutorial and best practices](https://gitlab.common-lisp.net/asdf/asdf/blob/master/doc/best_practices.md).
 
 <a name="example"></a>
 
-## An example
+## Simple examples
 
-This example shows how to use the defsystem facility available in Allegro Common Lisp 6.x. Suppose you are working on an HTML generation library, that is composed of three files: "top.cl", that defines a package for this library, "html.cl" that implements the basic HTML-generating operations, and "library.cl" that defines high-level functions and macros to generate HTML pages. A system definition for your library might look like this:
+### Loading a System
+
+The most trivial use of ASDF is by calling `(asdf:load-system :foobar)`
+to load your library.
+Then you can use it.
+For instance, if it exports a function `some-fun` in its package `foobar`,
+then you will be able to call it with `(foobar:some-fun ...)` or with:
+
+    (in-package :foobar)
+    (some-fun ...)
+
+You can also use Quicklisp:
+
+    (ql:quickload :foobar)
+
+### Testing a System
+
+To run the tests for a system, you may use:
+
+    (asdf:test-system :foobar)
+
+The convention is that an error SHOULD be signalled if tests are unsuccessful.
+
+### Designating a system
+
+The proper way to designate a system in a program is with lower-case
+strings, not symbols, as in:
+
+    (asdf:load-system "foobar")
+    (asdf:test-system "foobar")
+
+### Trivial System Definition
+
+A trivial system would have a single Lisp file called `foobar.lisp`.
+That file would depend on some existing libraries,
+say `alexandria` for general purpose utilities,
+and `trivia` for pattern-matching.
+To make this system buildable using ASDF,
+you create a system definition file called `foobar.asd`,
+with the following contents:
+
+    (defsystem "foobar"
+      :depends-on ("alexandria" "trivia")
+      :components ((:file "foobar")))
+
+Note how the type `lisp` of `foobar.lisp`
+is implicit in the name of the file above.
+As for contents of that file, they would look like this:
+
+    (defpackage :foobar
+      (:use :common-lisp :alexandria :trivia)
+      (:export
+       #:some-function
+       #:another-function
+       #:call-with-foobar
+       #:with-foobar))
+
+    (in-package :foobar)
+
+    (defun some-function (...)
+      ...)
+    ...
+
+#### Using the system you defined
+
+Assuming your system is installed under the `~/common-lisp/` hierarchy
+or some other filesystem hierarchy already configured for ASDF,
+you can load it with: `(asdf:load-system "foobar")`,
+or shorter `(asdf:make :foobar)`
+
+If your Lisp was already started when you created that file,
+you may have to `(asdf:clear-configuration)` to re-process the configuration.
+
+
+### Trivial Testing Definition
+
+Even the most trivial of systems needs some tests,
+if only because it will have to be modified eventually,
+and you want to make sure those modifications don't break client code.
+Tests are also a good way to document expected behavior.
+
+The simplest way to write tests is to have a file `foobar-tests.lisp`
+and modify the above `foobar.asd` as follows:
+
+    (defsystem "foobar"
+      :depends-on ("alexandria" "trivia")
+      :components ((:file "foobar"))
+      :in-order-to ((test-op (test-op "foobar/tests"))))
+
+    (defsystem "foobar/tests"
+      :depends-on ("foobar" "fiveam")
+      :components ((:file "foobar-tests"))
+      :perform (test-op (o c) (symbol-call :fiveam '#:run! :foobar)))
+
+The `:in-order-to` clause in the first system
+allows you to use `(asdf:test-system :foobar)`
+which will chain into `foobar/tests`.
+The `:perform` clause in the second system does the testing itself.
+
+In the test system, `fiveam` is the name of a popular test library,
+and the content of the `perform` method is how to invoke this library
+to run the test suite `:foobar`.
+Obvious YMMV if you use a different library.
+
+## Create a project skeleton
+
+[cl-project](https://github.com/fukamachi/cl-project) can be used to
+generate a project skeleton. It will create a default ASDF definition,
+it generates a system for unit testing, etc.
+
+Install with
+
+    (ql:quickload :cl-project)
+
+Create a project:
 
 ~~~lisp
-(defsystem :html
-    (:pretty-name "HTML generation library"
-     :default-pathname #P"/code/lisp/html/")
-  (:serial "top"
-           "html"
-           "library"))
+(cl-project:make-project #p"lib/cl-sample/"
+:author "Eitaro Fukamachi"
+:email "e.arrows@gmail.com"
+:license "LLGPL"
+:depends-on '(:clack :cl-annot))
+;-> writing /Users/fukamachi/Programs/lib/cl-sample/.gitignore
+;   writing /Users/fukamachi/Programs/lib/cl-sample/README.markdown
+;   writing /Users/fukamachi/Programs/lib/cl-sample/cl-sample-test.asd
+;   writing /Users/fukamachi/Programs/lib/cl-sample/cl-sample.asd
+;   writing /Users/fukamachi/Programs/lib/cl-sample/src/hogehoge.lisp
+;   writing /Users/fukamachi/Programs/lib/cl-sample/t/hogehoge.lisp
+;=> T
 ~~~
-
-The above form defines a system whose name is the symbol `:html`. After the system name comes a list containing optional information: in this case, we specified a human-readable name for the package, and the directory where the source files are located. Finally, the three files that compose the system are listed, with the `:serial` keyword indicating that they should be compiled and loaded in the specified order (possibly because each one depends on definitions in the previous ones).
-
-Having defined a system like the above, you can then operate on it. For example, calling:
-
-~~~lisp
-(load-system :html :compile t)
-~~~
-
-will cause the three files in the system to be compiled (if needed) and loaded.
-
-Note that a system can include other systems as components, and the included systems will be recursively compiled and loaded. For example, if we wanted the definitions in the `:util` system to be available to the `:html` system, we would change the above definition to:
-
-~~~lisp
-(defsystem :html
-    (:pretty-name "HTML generation library"
-     :default-pathname #P"/code/lisp/html/")
-  (:serial :util
-           "top"
-           "html"
-           "library"))
-~~~
-
-<a name="cross"></a>
-
-## Cross-platform defsystems
-
-The most advanced attempt at building a cross-platform system definition tool is probably **MK-DEFSYSTEM**, available from [CLOCC](http://sourceforge.net/projects/clocc). Please refer to that site for more details on how to install it and use it.
-
-<a name="begin"></a>
-
-## System construction for beginners
-
-Organizing a large Lisp system is not trivial: managing the interdependencies among a large number of source files and the interactions between multiple packages can easily turn into a complex undertaking that requires careful planning. Combine this with the fact that ANSI CL provides an alternative, although much more limited, way of managing code ([`provide`](http://www.lispworks.com/documentation/HyperSpec/Body/f_provid.htm) and [`require`](http://www.lispworks.com/documentation/HyperSpec/Body/f_provid.htm)), and the whole issue can quickly become a nightmare for beginners. So here is a suggestion on a possible way to organize your code, one that works best for small, self-contained packages with a well-defined API, and that provide functions that might be useful to other parts of a larger program. Just follow these three easy steps...
-
-1. Put the following in your Lisp initialization file:
-
-   ~~~lisp
-   (eval-when (:load-toplevel :execute)
-	 (shadow 'cl:require))
-
-   (defun require (system)
-	 (excl:load-system system :compile t)  ; *** ACL specific
-	 (unless (member system *modules*)
-	   (push system *modules*)
-	   (when (find-package system)
-		 (use-package system))))
-   ~~~
-
-   The `load-system` call is specific to ACL's defsystem, so you should replace it with the equivalent call for the defsystem you are using.
-
-2. Write your code so that it creates its own package, and exports all public symbols from it. Using the `:html` system defined above as an example:
-
-   ~~~lisp
-   (defpackage :html
-	 (:use :lisp)
-	 (:export "ANCHOR" "HEADER" ...))
-   ~~~
-
-3. Write a system definition for your code, giving the system the same name you used for the package (like the `defsystem` form for `:html` at the beginning of this chapter).
-
-Now you can simply call
-
-~~~lisp
-* (require :html)
-~~~
-
-and the system will be compiled (if needed) and loaded; moreover, all of its external symbols will be imported into the current package. If you later modify your code, you just have to call [`require`](http://www.lispworks.com/documentation/HyperSpec/Body/f_provid.htm) again, and the system will be recompiled and reloaded. This behaves approximately like the `use` command in Perl or the `import` statement in Java: it allows you to easily access the functionality provided by a Lisp package with a single command.


### PR DESCRIPTION
fixes #91 - "Defining Systems" page not mentioning ASDF ?
and removes an occurence of #39 - Review use of CLOCC

I copied parts of ASDF best practices document (removed some discussion) (MIT) and added cl-project. We could do more.