### PR TITLE
index: TOC and contributors lists in 2 and 4 columns

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -16,4 +16,10 @@ layout: default
      headings: "h1,h2,h3,h4"});
  }
 
+ $("#two-cols + ul").css({
+   "column-count": "2",
+ });
+ $("#contributors + ul").css({
+   "column-count": "4",
+ });
 </script>

--- a/index.md
+++ b/index.md
@@ -10,6 +10,8 @@ title: Home
 
 # Content
 
+<p id="two-cols"></p>
+
 * [License](license.html)
 * [Editor support](editor-support.html)
 * [Strings](strings.html)
@@ -58,6 +60,8 @@ The pages here on Github are kept up to date. You can also download a
 [Github project page][gh]. 
 
 ## Contributors
+
+<p id="contributors"></p>
 
 * Marco Antoniotti
 * [Zach Beane](mailto:xach@xach.com)


### PR DESCRIPTION
A jquery and CSS trick to put the global TOC on the index on two columns and the contributors list on four, so that we have the whole toc at a glance and less whitespace, less scrolling. Looks better to me:

![selection_163](https://user-images.githubusercontent.com/3721004/28269344-fdbd1c50-6b01-11e7-9085-1e07d7a64537.png)

![selection_164](https://user-images.githubusercontent.com/3721004/28269429-5e65ecbc-6b02-11e7-8f0b-3e104fa29516.png)
