### PR TITLE
Code coverage and CI

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ title: Home
 * [Threads](process.html)
 * [Defining Systems](systems.html)
 * [Using the Win32 API](win32.html)
-* [Testing](testing.html)
+* [Testing and Continuous Integration](testing.html)
 * [Web Scraping](web-scraping.html)
 * [Experimental CL21](cl21.html)
 * [Miscellaneous](misc.html)

--- a/testing.md
+++ b/testing.md
@@ -2,19 +2,24 @@
 title: Testing
 ---
 
-So you want to easily test the code you're writing? The following
-recipes cover how to write automated tests. We will use an established
-and well-designed regression testing framework called
-[Prove](https://github.com/fukamachi/prove). It is not the only
-possibility though, [FiveAM](http://quickdocs.org/fiveam/api) is a
-popular one. We prefer `Prove` for its doc and its **extensible
-reporters** (it has different report styles and we can extend
-them).
+So you want to easily test the code you're writing ? The following
+recipes cover how to write automated tests and see their code
+coverage. We also give pointers to plug those in modern continuous
+integration services like Travis CI and Coveralls.
+
+We will use an established and well-designed regression testing
+framework called [Prove](https://github.com/fukamachi/prove). It is
+not the only possibility though,
+[FiveAM](http://quickdocs.org/fiveam/api) is a popular one. We prefer
+`Prove` for its doc and its **extensible reporters** (it has different
+report styles and we can extend them).
 
 
 <a name="install"></a>
 
-## Load
+## Testing with Prove
+
+### Install and load
 
 `Prove` is in Quicklisp:
 
@@ -26,7 +31,7 @@ This command installs `prove` if necessary, and loads it.
 
 <a name="writetest"></a>
 
-## Write a test file
+### Write a test file
 
 ~~~lisp
 (in-package :cl-user)
@@ -48,7 +53,7 @@ Prove's API contains the following testing functions: `ok`, `is`,
 `skip`, `subtest`.
 
 
-## Run a test file
+### Run a test file
 
 ~~~lisp
 (prove:run #P"myapp/tests/my-test.lisp")
@@ -61,7 +66,7 @@ We get an output like:
      style="max-width: 800px"/>
 
 
-## More
+### More about Prove
 
 `Prove` can also:
 
@@ -77,3 +82,73 @@ We get an output like:
   author).
 
 See [Prove's documentation](https://github.com/fukamachi/prove) !
+
+## Code coverage
+
+A code coverage tool produces a visual output that allows to see what
+parts of our code were tested or not:
+
+
+![](assets/coverage.png "source: https://www.snellman.net/blog/archive/2007-05-03-code-coverage-tool-for-sbcl.html")
+
+
+### Generating an html test coverage output
+
+SBCL comes with a built-in module to do code coverage analysis:
+[sb-cover](http://www.sbcl.org/manual/index.html#sb_002dcover).
+
+Coverage reports are only generated for code compiled using
+`compile-file` with the value of the `sb-cover:store-coverage-data`
+optimization quality set to 3.
+
+~~~lisp
+;;; Load SB-COVER
+(require :sb-cover)
+
+;;; Turn on generation of code coverage instrumentation in the compiler
+(declaim (optimize sb-cover:store-coverage-data))
+
+;;; Load some code, ensuring that it's recompiled with the new optimization
+;;; policy.
+(asdf:oos 'asdf:load-op :cl-ppcre-test :force t)
+
+;;; Run the test suite.
+(cl-ppcre-test:test)
+~~~
+
+Produce a coverage report, set the output directory:
+
+~~~lisp
+(sb-cover:report "/tmp/report/")
+~~~
+
+Finally, turn off instrumentation:
+
+~~~lisp
+(declaim (optimize (sb-cover:store-coverage-data 0)))
+~~~
+
+This produces something like the capture above or
+[this code coverage of cl-ppcre](https://www.snellman.net/sbcl/cover/cl-ppcre-report-3/cover-index.html).
+
+
+### Continuous testing and test coverage with Travis CI and Coveralls
+
+[Travis](https://travis-ci.org/) is a service for running unit tests
+in the cloud and [Coveralls](https://coveralls.io/) shows you the
+evolution of coverage over time, and also tells you what a pull
+request will do to coverage.
+
+Thanks to `cl-travis` we can easily test our program against one or many
+Lisp implementations (ABCL, Allegro CL, SBCL, CMUCL, CCL and
+ECL). `cl-coveralls` helps to post our coverage to the service. It
+supports SBCL and Clozure CL with Travis CI and Circle CI.
+
+We refer you to the lengthy and illustrated explanations of the
+["continuous integration" page on lisp-lang.org](http://lisp-lang.org/learn/continuous-integration).
+
+You'll find many example projects using them in the links above, but
+if you want a quick overview of what it looks like:
+
+- Lucerne on [Coveralls](https://coveralls.io/github/eudoxia0/lucerne)
+  and [Travis](https://travis-ci.org/eudoxia0/lucerne).

--- a/testing.md
+++ b/testing.md
@@ -65,6 +65,11 @@ We get an output like:
 <img src="assets/prove-report.png"
      style="max-width: 800px"/>
 
+### Run one test
+
+You can directly run one test by compiling it. With Slime, use the
+usual `C-c C-c`.
+
 
 ### More about Prove
 
@@ -113,13 +118,13 @@ optimization quality set to 3.
 (asdf:oos 'asdf:load-op :cl-ppcre-test :force t)
 
 ;;; Run the test suite.
-(cl-ppcre-test:test)
+(prove:run :yoursystem-test)
 ~~~
 
 Produce a coverage report, set the output directory:
 
 ~~~lisp
-(sb-cover:report "/tmp/report/")
+(sb-cover:report "coverage/")
 ~~~
 
 Finally, turn off instrumentation:
@@ -128,7 +133,9 @@ Finally, turn off instrumentation:
 (declaim (optimize (sb-cover:store-coverage-data 0)))
 ~~~
 
-This produces something like the capture above or
+You can open your browser at
+`../yourproject/t/coverage/cover-index.html` to see the report like
+the capture above or like
 [this code coverage of cl-ppcre](https://www.snellman.net/sbcl/cover/cl-ppcre-report-3/cover-index.html).
 
 


### PR DESCRIPTION
about the built-in SBCL sb-cover and link to lisp-lang.org's very nice tutorial for CI and coveralls.

If someone could explain the relation between cl-coveralls and sb-cover, and is there a way to run sb-cover with less manual steps ? (or put them in a Makefile ?)

- https://github.com/fukamachi/cl-coveralls 
- http://www.sbcl.org/manual/sb_002dcover.html