### PR TITLE
Read a file in utf-8, avoid typical "ASCII stream decoding error"

### DIFF
--- a/files.md
+++ b/files.md
@@ -161,6 +161,16 @@ of using elements of type character everytime. For instance, you can set
 `:ELEMENT-TYPE` type argument of `WITH-OUTPUT-TO-STRING`, `WITH-OPEN-FILE` and
 `MAKE-ARRAY` functions to `'(UNSIGNED-BYTE 8)` to read data in octets.
 
+### Reading with an UTF-8 encoding
+
+To avoid an `ASCII stream decoding error` you might want to specify an UTF-8 encoding:
+
+~~~lisp
+(with-open-file (in "/path/to/big/file"
+                     :external-format :utf-8)
+                 ...
+~~~
+
 ### Looking one Character ahead
 
 You can 'look at' the next character of a stream without actually removing it


### PR DESCRIPTION
thanks to
https://stackoverflow.com/questions/12645978/ascii-stream-decoding-error-in-cl-html-parse

and why not this shorter function to read a file into a string ?
```

(defun file-string (path)
  (with-open-file (stream path)
    (let ((data (make-string (file-length stream))))
      (read-sequence data stream)
      data)))
```
https://rosettacode.org/wiki/Read_entire_file#Common_Lisp (it may give a limitation)

instead of what we have:

```
(with-output-to-string (out)
  (with-open-file (in "/path/to/big/file")
    (loop with buffer = (make-array 8192 :element-type 'character)
          for n-characters = (read-sequence buffer in)
          while (< 0 n-characters)
          do (write-sequence buffer out :start 0 :end n-characters)))))

```
