### PR TITLE
how to get and parse command line arguments (portable way)

### DIFF
--- a/os.md
+++ b/os.md
@@ -53,11 +53,14 @@ systems including Windows. It is also `fset`-able.
 
 ## Accessing the command line arguments
 
+### Basics
+
 Accessing command line arguments is implementation-specific but it
 appears most implementations have a way of getting at
-them. [Roswell](https://github.com/roswell/roswell/wiki) makes it portable.
+them. [Roswell](https://github.com/roswell/roswell/wiki) or external
+libraries (see next section) make it portable.
 
-[SBCL](http://www.sbcl.org) has the special variable `sb-ext:*posix-argv*`
+[SBCL](http://www.sbcl.org) stores the arguments list in the special variable `sb-ext:*posix-argv*`
 
 ~~~lisp
 $ sbcl my-command-line-arg
@@ -93,6 +96,91 @@ Here's a quick function to return the argument strings list across multiple impl
    #+CMU extensions:*command-line-words*
    nil))
 ~~~
+
+Now it would be handy to access them in a portable way and to parse
+them according to a schema definition.
+
+### Parsing command line arguments
+
+We have a look at the
+[Awesome CL list#scripting](https://github.com/CodyReichert/awesome-cl#scripting)
+section and we'll show how to use [unix-opts](https://github.com/mrkkrp/unix-opts).
+
+~~~lisp
+(ql:quickload "unix-opts")
+~~~
+
+We can now refer to it with its `opts` nickname.
+
+We first declare our arguments with `opts:define-opts`, for example
+
+~~~lisp
+(opts:define-opts
+    (:name :help
+           :description "print this help text"
+           :short #\h
+           :long "help")
+    (:name :level
+           :description "The level of something (integer)."
+           :short #\l
+           :long "level"
+           :arg-parser #'parse-integer))
+~~~
+
+Everything should be self-explanatory. Note that `#'parse-integer` is
+a built-in CL function.
+
+Now we can parse and get them with `opts:get-opts`, which returns two
+values: the first is the list of valid options and the second the
+remaining free arguments. We then must use multiple-value-bind to
+catch everything:
+
+~~~lisp
+(multiple-value-bind (options free-args)
+    ;; There is no error handling yet (specially for options not having their argument).
+    (opts:get-opts)
+~~~
+
+We can explore this by giving a list of strings (as options) to
+`get-opts`:
+
+
+~~~lisp
+(multiple-value-bind (options free-args)
+                   (opts:get-opts '("hello" "-h" "-l" "1"))
+                 (format t "Options: ~a~&" options)
+                 (format t "free args: ~a~&" free-args))
+Options: (HELP T LEVEL 1)
+free args: (hello)
+NIL
+~~~
+
+If we put an unknown option, we get into the debugger. We refer you to
+unix-opts' documentation and code sample to deal with erroneous
+options and other errors.
+
+We can access the arguments stored in `options` with `getf` (it is a
+property list), and we can exit (in a portable way) with
+`opts:exit`. So, for example:
+
+~~~lisp
+(multiple-value-bind (options free-args)
+    ;; No error handling.
+    (opts:get-opts)
+
+  (if (getf options :help)
+      (progn
+        (opts:describe
+         :prefix "My app. Usage:"
+         :args "[keywords]")
+        (exit))) ;; <= exit takes an optional return status.
+    ...
+~~~
+
+And that's it for now, you know the essential. See the documentation
+for a complete example, and the Awesome CL list for useful packages to
+use in the terminal (ansi colors, printing tables and progress bars,
+interfaces to readline,…).
 
 
 <a name="fork-cmucl"></a>


### PR DESCRIPTION
could be in a future "scripting" section.

and already fixes #4 - add package name for *POSIX-ARGV* in os.html [from sourceforge]

read: https://vindarel.github.io/cl-cookbook/os.html#parsing-command-line-arguments

(from my https://vindarel.github.io/cl-torrents/tutorial.html#org0139d5d)