### PR TITLE
added basic recipes for using CL-PPCRE

### DIFF
--- a/pattern_matching.md
+++ b/pattern_matching.md
@@ -18,3 +18,97 @@ Note that some CL implementations include regexp facilities, notably
 [CLISP](http://clisp.sourceforge.net/impnotes.html#regexp) and
 [ALLEGRO CL](https://franz.com/support/documentation/current/doc/regexp.htm). If
 in doubt, check your manual or ask your vendor.
+
+Description provided below is far from complete, so don't forget to
+check the reference manual that comes along with the CL-PPCRE library.
+
+
+## Using PPCRE
+
+CL-PPCRE (abbreviation for Portable Perl-compatible regular
+expressions) is a portable regular expression library for Common Lisp
+with a broad set of features and good performance. It has been ported
+to a number of Common Lisp implementations and can be easily installed
+(or added as a dependency) via Quicklisp:
+
+~~~lisp
+(ql:quickload "cl-ppcre")
+~~~
+
+It might be more convenient to use CL-PPCRE with the CL-INTERPOL
+library. CL-INTERPOL is a library for Common Lisp which modifies the
+reader in a way that introduces interpolation within strings similar
+to Perl or Unix Shell scripts.
+
+In addition to loading the CL-INTERPOL library, initialization call
+must be made to properly configure the Lisp reader. This is
+accomplished by either calling the `enable-interpol-syntax` function
+from the REPL or placing that call in the source file before using any
+of its features:
+
+~~~lisp
+(interpol:enable-interpol-syntax)
+~~~
+
+Basic operations with the CL-PPCRE library functions are described
+below.
+
+
+## Looking for matching patterns
+
+The `scan` function tries to match the given pattern and on success
+returns four values - the start of the match, the end of the match,
+and two arrays denoting the beginnings and ends of register
+matches. On failure returns `NIL`.
+
+A regular expression pattern can be compiled with the `create-scanner`
+function call. A "scanner" will be created that can be used by other
+functions.
+
+For example:
+
+~~~lisp
+(let ((ptrn (ppcre:create-scanner "(a)*b")))
+  (ppcre:scan ptrn "xaaabd"))
+~~~
+
+will yield the same results as:
+
+~~~lisp
+(ppcre:scan "(a)*b" "xaaabd")
+~~~
+
+but will require less time for repeated `scan` calls as parsing the
+expression and compiling it is done only once.
+
+
+## Extracting information
+
+CL-PPCRE provides a several ways to extract matching fragments, among
+them: the `scan-to-strings` and `register-groups-bind` functions.
+
+The `scan-to-strings` function is similar to `scan` but returns
+substrings of target-string instead of positions, i.e. this function
+returns two values on success: the whole match as a string plus an
+array of substrings (or NILs) corresponding to the matched registers.
+
+The `register-groups-bind` function tries to match the given pattern
+against the target string and binds matching fragments with the given
+variables.
+
+~~~lisp
+(ppcre:register-groups-bind (first second third fourth)
+      ("((a)|(b)|(c))+" "abababc" :sharedp t)
+    (list first second third fourth))
+;; => ("c" "a" "b" "c")
+~~~
+
+It also provides a shortcut for calling a function before assigning
+the matching fragment to the variable:
+
+~~~lisp
+(ppcre:register-groups-bind (fname lname (#'parse-integer date month year))
+      ("(\\w+)\\s+(\\w+)\\s+(\\d{1,2})\\.(\\d{1,2})\\.(\\d{4})" "Frank Zappa 21.12.1940")
+    (list fname lname (encode-universal-time 0 0 0 date month year 0)))
+;; => ("Frank" "Zappa" 1292889600)
+~~~

--- a/pattern_matching.md
+++ b/pattern_matching.md
@@ -8,7 +8,7 @@ does not include facilities for pattern matching and regular
 expressions, but a couple of libraries exist for those tasks: see
 [Optima](https://github.com/m2ym/optima) or
 [Trivia](https://github.com/guicho271828/trivia) for pattern matching
-and [cl-ppcre](http://weitz.de/cl-ppcre/) for regular expressions.
+and [cl-ppcre](https://github.com/edicl/cl-ppcre) for regular expressions.
 
 See also the respective
 [Cliki: pattern matching](http://www.cliki.net/pattern%20matching) and
@@ -19,35 +19,23 @@ Note that some CL implementations include regexp facilities, notably
 [ALLEGRO CL](https://franz.com/support/documentation/current/doc/regexp.htm). If
 in doubt, check your manual or ask your vendor.
 
-Description provided below is far from complete, so don't forget to
-check the reference manual that comes along with the CL-PPCRE library.
+The description provided below is far from complete, so don't forget
+to check the reference manual that comes along with the CL-PPCRE
+library.
 
+# PPCRE
 
 ## Using PPCRE
 
-CL-PPCRE (abbreviation for Portable Perl-compatible regular
-expressions) is a portable regular expression library for Common Lisp
-with a broad set of features and good performance. It has been ported
-to a number of Common Lisp implementations and can be easily installed
-(or added as a dependency) via Quicklisp:
+[CL-PPCRE](https://github.com/edicl/cl-ppcre) (abbreviation for
+Portable Perl-compatible regular expressions) is a portable regular
+expression library for Common Lisp with a broad set of features and
+good performance. It has been ported to a number of Common Lisp
+implementations and can be easily installed (or added as a dependency)
+via Quicklisp:
 
 ~~~lisp
 (ql:quickload "cl-ppcre")
-~~~
-
-It might be more convenient to use CL-PPCRE with the CL-INTERPOL
-library. CL-INTERPOL is a library for Common Lisp which modifies the
-reader in a way that introduces interpolation within strings similar
-to Perl or Unix Shell scripts.
-
-In addition to loading the CL-INTERPOL library, initialization call
-must be made to properly configure the Lisp reader. This is
-accomplished by either calling the `enable-interpol-syntax` function
-from the REPL or placing that call in the source file before using any
-of its features:
-
-~~~lisp
-(interpol:enable-interpol-syntax)
 ~~~
 
 Basic operations with the CL-PPCRE library functions are described
@@ -57,9 +45,9 @@ below.
 ## Looking for matching patterns
 
 The `scan` function tries to match the given pattern and on success
-returns four values - the start of the match, the end of the match,
-and two arrays denoting the beginnings and ends of register
-matches. On failure returns `NIL`.
+returns four multiple-values values - the start of the match, the end
+of the match, and two arrays denoting the beginnings and ends of
+register matches. On failure returns `NIL`.
 
 A regular expression pattern can be compiled with the `create-scanner`
 function call. A "scanner" will be created that can be used by other
@@ -88,7 +76,7 @@ CL-PPCRE provides a several ways to extract matching fragments, among
 them: the `scan-to-strings` and `register-groups-bind` functions.
 
 The `scan-to-strings` function is similar to `scan` but returns
-substrings of target-string instead of positions, i.e. this function
+substrings of target-string instead of positions. This function
 returns two values on success: the whole match as a string plus an
 array of substrings (or NILs) corresponding to the matched registers.
 
@@ -103,8 +91,8 @@ variables.
 ;; => ("c" "a" "b" "c")
 ~~~
 
-It also provides a shortcut for calling a function before assigning
-the matching fragment to the variable:
+CL-PPCRE also provides a shortcut for calling a function before
+assigning the matching fragment to the variable:
 
 ~~~lisp
 (ppcre:register-groups-bind (fname lname (#'parse-integer date month year))
@@ -112,3 +100,24 @@ the matching fragment to the variable:
     (list fname lname (encode-universal-time 0 0 0 date month year 0)))
 ;; => ("Frank" "Zappa" 1292889600)
 ~~~
+
+## Syntactic sugar
+
+It might be more convenient to use CL-PPCRE with the
+[CL-INTERPOL](https://github.com/edicl/cl-interpol)
+library. CL-INTERPOL is a library for Common Lisp which modifies the
+reader in a way that introduces interpolation within strings similar
+to Perl, Scala, or Unix Shell scripts.
+
+In addition to loading the CL-INTERPOL library, initialization call
+must be made to properly configure the Lisp reader. This is
+accomplished by either calling the `enable-interpol-syntax` function
+from the REPL or placing that call in the source file before using any
+of its features:
+
+~~~lisp
+(interpol:enable-interpol-syntax)
+~~~
+
+A lot more syntax sugar is introduced by the [cl21](cl21.html) project
+but in a somewhat more intrusive way.


### PR DESCRIPTION
This misses issue #41 a bit, but still might be a valuable starting point for recipes for working with the regular expressions.

A lot more information can be added in the future, but still at least something as the start (esp. after cl-ppcre documentation is missing at its standard location at the time).