### PR TITLE
Provide source link for easier fixes

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -5,6 +5,10 @@ layout: default
 
 <div id="content"
   {{ content }}
+
+  <p>
+    Page source: <a href="https://github.com/LispCookbook/cl-cookbook/blob/master/{{ page.path }}">{{ page.path }}</a>
+  </p>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
Current pages have no links to the github source (apart from index page) and it's a possible friction point for more contributions