### PR TITLE
CSS: distinguish link to page source from page content

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -6,7 +6,7 @@ layout: default
 <div id="content"
   {{ content }}
 
-  <p>
+  <p class="page-source">
     Page source: <a href="https://github.com/LispCookbook/cl-cookbook/blob/master/{{ page.path }}">{{ page.path }}</a>
   </p>
 </div>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -26,6 +26,13 @@ footer {
     margin-left: 25%;
 }
 
+.page-source {
+    background-color: #add8e6;
+    padding: 1em;
+    text-align: center;
+    opacity: 0.9;
+}
+
 /* On small screens we remove left column to make text more readable */
 @media screen and (max-width: 40em) {
     #toc {


### PR DESCRIPTION
Some CSS around "page source", to distinguish it from page content and make it even more attractive.

![selection_199](https://user-images.githubusercontent.com/3721004/34519248-4ccbf832-f083-11e7-937d-21ee2559f247.png)

(welcome to designers)