### PR TITLE
Files: read a file with uiop (no Alexandria), write to file

### DIFF
--- a/files.md
+++ b/files.md
@@ -72,10 +72,10 @@ typical use of `with-open-file` looks like this:
 
 ~~~lisp
 (with-open-file (str <_file-spec_>
-:direction <_direction_>
-:if-exists <_if-exists_>
-:if-does-not-exist <_if-does-not-exist_>)
-<_your code here_>)
+    :direction <_direction_>
+    :if-exists <_if-exists_>
+    :if-does-not-exist <_if-does-not-exist_>)
+  <_your code here_>)
 ~~~
 
 *   `str` is a variable which'll be bound to the stream which is created by
@@ -102,7 +102,6 @@ for all the details. You'll find some examples on how to use `with-open-file`
 below. Also note that you usually don't need to provide any keyword arguments if
 you just want to open an existing file for reading.<a name="strings">
 
-### Using Strings instead of Files
 
 ### Reading a File one Line at a Time
 
@@ -150,15 +149,28 @@ characters by this function.
        (print char)))
 ~~~
 
-### Reading a File into a String
+### Reading a File into a String or a List of Lines
 
 It's quite common to need to access the contents of a file in string
-form.
+form, or to get a list of lines.
 
-Alexandria offers this function: [read-file-into-string](https://common-lisp.net/project/alexandria/draft/alexandria.html#IO). It accepts an `:external-format` argument (that can be bound to `:utf-8`). It is included in [cl21](cl21.html).
+`[uiop](https://github.com/fare/asdf/blob/master/uiop/stream.lisp#L445)` is included in ASDF (there is no extra library to install or
+system to load) and has the following function:
 
 
-Without Alexandria, this can be achieved by using `read-line` or `read-char` functions,
+~~~lisp
+(uiop:read-file-string "file.txt")
+~~~
+
+and
+
+~~~lisp
+(uiop:read-file-lines "file.txt")
+~~~
+
+
+
+**Otherwise**, this can be achieved by using `read-line` or `read-char` functions,
 that probably won't be the best solution. File might not be divided into
 multiple lines or reading one character at a time might bring significant
 performance problems. To solve this problems, you can read files using buckets
@@ -178,7 +190,7 @@ of using elements of type character everytime. For instance, you can set
 `:element-type` type argument of `with-output-to-string`, `with-open-file` and
 `make-array` functions to `'(unsigned-byte 8)` to read data in octets.
 
-### Reading with an UTF-8 encoding
+#### Reading with an UTF-8 encoding
 
 To avoid an `ASCII stream decoding error` you might want to specify an UTF-8 encoding:
 
@@ -188,7 +200,7 @@ To avoid an `ASCII stream decoding error` you might want to specify an UTF-8 enc
                  ...
 ~~~
 
-### Set SBCL's default encoding format to utf-8
+#### Set SBCL's default encoding format to utf-8
 
 Sometimes you don't control the internals of a library, so you'd
 better set the default encoding to utf-8.  Add this line to your

--- a/files.md
+++ b/files.md
@@ -103,59 +103,13 @@ below. Also note that you usually don't need to provide any keyword arguments if
 you just want to open an existing file for reading.<a name="strings">
 
 
-### Reading a File one Line at a Time
-
-[`read-line`](http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_lin.htm)
-will read one line from a stream (which defaults to
-[_standard input_](http://www.lispworks.com/documentation/HyperSpec/Body/26_glo_s.htm#standard_input))
-the end of which is determined by either a newline character or the end of the
-file. It will return this line as a string _without_ the trailing newline
-character. (Note that `read-line` has a second return value which is true if there
-was no trailing newline, i.e. if the line was terminated by the end of the
-file.) `read-line` will by default signal an error if the end of the file is
-reached. You can inhibit this by supplying NIL as the second argument. If you do
-this, `read-line` will return `nil` if it reaches the end of the file.
-
-~~~lisp
-(with-open-file (stream "/etc/passwd")
-  (do ((line (read-line stream nil)
-       (read-line stream nil)))
-       ((null line))
-       (print line)))
-~~~
-
-You can also supply a third argument which will be used instead of `nil` to signal
-the end of the file:
-
-~~~lisp
-(with-open-file (stream "/etc/passwd")
-  (loop for line = (read-line stream nil 'foo)
-   until (eq line 'foo)
-   do (print line)))
-~~~
-
-### Reading a File one Character at a Time
-
-[`read-char`](http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_cha.htm)
-is similar to `read-line`, but it only reads one character as opposed to one
-line. Of course, newline characters aren't treated differently from other
-characters by this function.
-
-~~~lisp
-(with-open-file (stream "/etc/passwd")
-  (do ((char (read-char stream nil)
-       (read-char stream nil)))
-       ((null char))
-       (print char)))
-~~~
-
 ### Reading a File into a String or a List of Lines
 
 It's quite common to need to access the contents of a file in string
 form, or to get a list of lines.
 
-`[uiop](https://github.com/fare/asdf/blob/master/uiop/stream.lisp#L445)` is included in ASDF (there is no extra library to install or
-system to load) and has the following function:
+[uiop](https://github.com/fare/asdf/blob/master/uiop/stream.lisp#L445) is included in ASDF (there is no extra library to install or
+system to load) and has the following functions:
 
 
 ~~~lisp
@@ -211,6 +165,52 @@ better set the default encoding to utf-8.  Add this line to your
 and optionnally
 
     (setf sb-alien::*default-c-string-external-format* :utf-8)
+
+### Reading a File one Line at a Time
+
+[`read-line`](http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_lin.htm)
+will read one line from a stream (which defaults to
+[_standard input_](http://www.lispworks.com/documentation/HyperSpec/Body/26_glo_s.htm#standard_input))
+the end of which is determined by either a newline character or the end of the
+file. It will return this line as a string _without_ the trailing newline
+character. (Note that `read-line` has a second return value which is true if there
+was no trailing newline, i.e. if the line was terminated by the end of the
+file.) `read-line` will by default signal an error if the end of the file is
+reached. You can inhibit this by supplying NIL as the second argument. If you do
+this, `read-line` will return `nil` if it reaches the end of the file.
+
+~~~lisp
+(with-open-file (stream "/etc/passwd")
+  (do ((line (read-line stream nil)
+       (read-line stream nil)))
+       ((null line))
+       (print line)))
+~~~
+
+You can also supply a third argument which will be used instead of `nil` to signal
+the end of the file:
+
+~~~lisp
+(with-open-file (stream "/etc/passwd")
+  (loop for line = (read-line stream nil 'foo)
+   until (eq line 'foo)
+   do (print line)))
+~~~
+
+### Reading a File one Character at a Time
+
+[`read-char`](http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_cha.htm)
+is similar to `read-line`, but it only reads one character as opposed to one
+line. Of course, newline characters aren't treated differently from other
+characters by this function.
+
+~~~lisp
+(with-open-file (stream "/etc/passwd")
+  (do ((char (read-char stream nil)
+       (read-char stream nil)))
+       ((null char))
+       (print char)))
+~~~
 
 ### Looking one Character ahead
 

--- a/files.md
+++ b/files.md
@@ -344,6 +344,29 @@ CL-USER> (with-input-from-string (stream "I'm not amused")
 5
 ~~~
 
+### Writing content to a file
+
+With `with-open-file`, specify `:direction :output` and use `write-sequence` inside:
+
+~~~lisp
+(with-open-file (f <pathname> :direction :output
+                              :if-exists :supersede
+                              :if-does-not-exist :create)
+    (write-sequence s f)))
+~~~
+
+If the file exists, you can also `:append` content to it.
+
+If it doesn't exist, you can `:error` out. See the standard for more details.
+
+
+The library [str](https://github.com/vindarel/cl-str) has a shortcut:
+
+~~~lisp
+(str:to-file "file.txt" content) ;; with optional options
+~~~
+
+
 ### Getting file attributes (size, access time,...), with the Osicat library
 
 [Osicat](https://www.common-lisp.net/project/osicat/) (in Quicklisp)


### PR DESCRIPTION
Just learned about uiop:read-file-[string,lines], so no need of Alexandria for that.

Added quick section "write to file".