### PR TITLE
data structures: sort is destructive, use copy-seq beforehand.

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -399,6 +399,10 @@ length of the one to replace.
 
 #### sort, stable-sort (sequence, test [, key function])
 
+These sort functions are destructive, so one may prefer to copy the sequence before sorting:
+
+    (sort (copy-seq seq) :test #'string<)
+
 #### find, position (foo, sequence)
 
 also `find-if`, `find-if-not`, `position-if`, `position-if-not` *(test


### PR DESCRIPTION
sort is destructive ! Got hit by that, copy-seq did the trick.