### PR TITLE
Fix link to serapeum reference

### DIFF
--- a/cl21.md
+++ b/cl21.md
@@ -29,7 +29,7 @@ other related projects, that go beyond
 - [Serapeum](https://github.com/TBRSS/serapeum) is a set of utilities
   beyond Alexandria, as a supplement. It defines a lot of helper
   functions (see its
-  [reference](https://github.com/TBRSS/serapeum/blob/master/reference.md))
+  [reference](https://github.com/TBRSS/serapeum/blob/master/REFERENCE.md))
   for macros, data structures (including more functions for trees,
   queues), sequences (`partition`, `keep`,…), strings, definitions
   (`defalias`,…),… no new reader macros here.


### PR DESCRIPTION
Changed from `reference.md` to `REFERENCE.md`