### PR TITLE
Link to modern public domain online CLOS MOP specification.

### DIFF
--- a/index.md
+++ b/index.md
@@ -46,6 +46,7 @@ title: Home
 * The [Awesome-cl](https://github.com/CodyReichert/awesome-cl) list
 * [The Common Lisp HyperSpec](http://www.lispworks.com/documentation/HyperSpec/Front/index.htm) by Kent M. Pitman
 * [The Common Lisp UltraSpec](http://phoe.tymoon.eu/clus/doku.php)
+* [CLOS MOP specification](https://clos-mop.hexstreamsoft.com/) (modern public domain version)
 * [Practical Common Lisp](http://www.gigamonkeys.com/book/) by Peter Seibel
 * [Common Lisp Recipes](http://weitz.de/cl-recipes/) by Edmund Weitz, published in 2016,
 * [Cliki](http://www.cliki.net/), Common Lisp's wiki


### PR DESCRIPTION
[Almost entirely copy/pasted from [a similar pull request on awesome-cl](https://github.com/CodyReichert/awesome-cl/pull/124).]

Hello,

My modern public domain online version of the CLOS MOP specification was first released on 15 october 2017, and after further improvements, although my full vision has not yet been realized I feel this is in quite good enough shape to submit to the "Other CL Resources" section of the Common Lisp cookbook.

Full faithfulness to the contents of the book has been a top priority, which was ensured by carefully auditing the new version against the actual book, so this is very complete and safe to use. Mobile support is already implemented, and offline support and further improvements are underway.

I think it's safe to say that most people would prefer to use this new version over any other previously existing versions. A cursory look at my version should easily convince most people of this.

https://clos-mop.hexstreamsoft.com/

I hope this is to your satisfaction.

-------------------------------------------

(I inserted my entry right after the CLHS and CLUS entries because the CLOS MOP is probably the most important Common Lisp de-facto standard, and it is widely supported in all modern Common Lisp implementations, and users can easily make use of it through the `closer-mop` de-facto standard compatibility library (which was a Top 3 Common Lisp library for all of 2017 according to Quicklisp download stats). (I also wonder in passing if the CLUS entry should be a bit lower due to incompleteness, but I don't want to be a dick about it.))

(I added the "(modern public domain version)" part because I think quite a lot of people, when seeing "CLOS MOP specification", would think this is just either the old copyrighted no-modifications-allowed version or the Robert Strandh version.)

(Note that all or almost all of the CSS validation "errors" (as seen when clicking on "✔ CSS3" at the bottom of the page) stem from the validator not yet supporting CSS variables, a widely supported feature in all modern standards-compliant browsers. I consider this a bug in the validator.)