### PR TITLE
databases: fix with-empty-db macro

### DIFF
--- a/databases.md
+++ b/databases.md
@@ -844,7 +844,8 @@ tables, runs the code and connects back to the original DB connection.
                                (random-string 8)
                                "/"))
           ;; Save our current DB connection.
-          (connection mito:*connection*))
+          (connection (when (mito.connection:connected-p)
+                        mito:*connection*)))
      (uiop:with-temporary-file (:pathname name :prefix prefix)
        ;; Bind our *db-name* to a new name, so as to create a new DB.
        (let* ((*db-name* name))


### PR DESCRIPTION
avoid "unbound variable" error. Indeed, mito:*connection* is unbound
by default, not nil, so this can fail if we don't connect to our DB
before running the tests (which is unlogic).