### PR TITLE
updated expired CL standard link

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -10,7 +10,7 @@ also have many more details:
 - [Practical CL](http://gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html), by Peter Seibel
 - [CL Recipes](http://weitz.de/cl-recipes/), by E. Weitz, full of explanations and tips,
 - the
-  [CL standard](http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html)
+  [CL standard](https://web.archive.org/web/20190630183107/http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html)
   with a nice TOC, functions reference, extensive descriptions, more
   examples and warnings (i.e: everything).
 - a [Common Lisp quick reference](http://clqr.boundp.org/)

--- a/data-structures.md
+++ b/data-structures.md
@@ -12,7 +12,7 @@ also have many more details:
 - the
   [CL standard](https://web.archive.org/web/20190630183107/http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html)
   with a nice TOC, functions reference, extensive descriptions, more
-  examples and warnings (i.e: everything).
+  examples and warnings (i.e: everything). [PDF mirror](https://gitlab.com/vancan1ty/clstandard_build/-/blob/master/cl-ansi-standard-draft-w-sidebar.pdf)
 - a [Common Lisp quick reference](http://clqr.boundp.org/)
 
 Don't miss the appendix and when you need more data structures, have a

--- a/data-structures.md
+++ b/data-structures.md
@@ -10,7 +10,7 @@ also have many more details:
 - [Practical CL](http://gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html), by Peter Seibel
 - [CL Recipes](http://weitz.de/cl-recipes/), by E. Weitz, full of explanations and tips,
 - the
-  [CL standard](https://web.archive.org/web/20190630183107/http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html)
+  [CL standard](http://cberr.us/tech_writings/notes/common_lisp_standard_draft.html)
   with a nice TOC, functions reference, extensive descriptions, more
   examples and warnings (i.e: everything). [PDF mirror](https://gitlab.com/vancan1ty/clstandard_build/-/blob/master/cl-ansi-standard-draft-w-sidebar.pdf)
 - a [Common Lisp quick reference](http://clqr.boundp.org/)


### PR DESCRIPTION
cvberry site for the CL Standard is link-rotted and now an aggressive link-farm. Updated to archive.org link for now, will have to review the copyright status on the PDF ( questionable license, as far as I understand)
Posting an update to an existing issue dealing with link-rot.