### PR TITLE
Codebase navigation tip

### DIFF
--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -323,6 +323,12 @@ See also helm-imenu and [imenu-anywhere](https://github.com/vspinu/imenu-anywher
 Put the cursor on any symbol and press `M-.` to go to its
 definition. Press `M-,` to come back.
 
+---
+**CODEBASE NAVIGATION TIP**
+
+Use `M-- M-.` (slime-edit-definition with a prefix argument) in order to autocomplete and then navigate to any loaded definition.
+---
+
 #### Crossreferencing: find who's calling, referencing, setting a symbol
 
 Slime has a nice cross referencing facility, for example, you can see

--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -320,13 +320,17 @@ See also helm-imenu and [imenu-anywhere](https://github.com/vspinu/imenu-anywher
 
 #### Go to definition
 
-Put the cursor on any symbol and press `M-.` to go to its
+Put the cursor on any symbol and press `M-.` (`slime-edit-definition`) to go to its
 definition. Press `M-,` to come back.
 
 ---
 **CODEBASE NAVIGATION TIP**
 
-Use `M-- M-.` (slime-edit-definition with a prefix argument) in order to autocomplete and then navigate to any loaded definition.
+Use `C-u M-.` (`slime-edit-definition` with a prefix argument) to autocomplete the symbol and navigate to it. This command always asks for a symbol even if the cursor is on one. It works with any loaded definition.
+
+You can think of it as a `imenu` completion that always work for any Lisp symbol.
+
+Note that the prefix argument can be given with other keys, like `M--`, which is more convenient on some keyboards.
 ---
 
 #### Crossreferencing: find who's calling, referencing, setting a symbol

--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -326,9 +326,9 @@ definition. Press `M-,` to come back.
 ---
 **CODEBASE NAVIGATION TIP**
 
-Use `C-u M-.` (`slime-edit-definition` with a prefix argument) to autocomplete the symbol and navigate to it. This command always asks for a symbol even if the cursor is on one. It works with any loaded definition.
+Use `C-u M-.` (`slime-edit-definition` with a prefix argument) to autocomplete the symbol and navigate to it. This command always asks for a symbol even if the cursor is on one. It works with any loaded definition. Here's a little [demonstration video](https://www.youtube.com/watch?v=ZAEt73JHup8).
 
-You can think of it as a `imenu` completion that always work for any Lisp symbol.
+You can think of it as a `imenu` completion that always work for any Lisp symbol. Add in [Slime's fuzzy completion][slime-fuzzy] for maximum powerness!
 
 Note that the prefix argument can be given with other keys, like `M--`, which is more convenient on some keyboards.
 ---
@@ -871,3 +871,5 @@ C-x 4 .         slime-edit-definition-other-window
 
 C-c C-v M-o     slime-clear-presentations
 ```
+
+[slime-fuzzy]: https://common-lisp.net/project/slime/doc/html/Fuzzy-Completion.html


### PR DESCRIPTION
Use slime-edit-definition with a prefix argument in order to autocomplete and then navigate to any loaded definition.

Feel free to rephrase or discard if you don't think this tip is valuable, but I found it very handy now that I've discovered it.