### PR TITLE
add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository
+
+# github: [vindarel,] # we can put 4 handles here.
+# we can only put 1 handle below:
+ko_fi: vindarel
+liberapay: vindarel
+patreon: vindarel
+# and again, up to 4 custom links:
+# custom: [link1, …, link4]


### PR DESCRIPTION
Hello,

So as I gather information about CL developers accepting donations (https://github.com/vindarel/lisp-maintainers/pull/1), I also try to push myself, since I am in a period where I don't have a fixed, nor big, income.

I added myself here (since I am the main contributor and I am still active) but actually we can list more than one contributor. The "♥ Sponsor" button that would appear can display github sponsors links for up to 4 people, and we can add up to 4 custom links.

So I would like to be sure that this PR doesn't cause a problem to anybody. 

And if this new button caused uncertainty and doubt in the future, the maintainers (including myself) can still revert this change.

Best,