### PR TITLE
rm cl21 from the index. We can't recommend it (anymore…)

### DIFF
--- a/cl21.md
+++ b/cl21.md
@@ -2,6 +2,12 @@
 title: Common Lisp for the 21st century
 ---
 
+CAUTION: We were excited by `CL21`, but we must admit that the project
+is staling and suffers from unresolved issues. We can't recommend it
+anymore. Hopefully, you'll now find many equivalent features in other
+libraries (`generic-cl`, `rutils`, `access` and many more).
+
+
 [CL21](http://cl21.org/) is an experimental project redesigning Common
 Lisp. It makes some common things that were tedious to do much easier
 and brings some new welcome features:
@@ -33,7 +39,7 @@ other related projects, that go beyond
   for macros, data structures (including more functions for trees,
   queues), sequences (`partition`, `keep`,…), strings, definitions
   (`defalias`,…),… no new reader macros here.
-
+- [generic-cl](https://github.com/alex-gutev/generic-cl/) is a generic interface to standard Common Lisp functions.
 
 ## Motivation
 

--- a/index.md
+++ b/index.md
@@ -46,7 +46,6 @@ title: Home
 * [Web development](web.html)
 * [Web Scraping](web-scraping.html)
 * [WebSockets](websockets.html)
-* [Experimental CL21](cl21.html)
 * [Miscellaneous](misc.html)
 
 ## Translations


### PR DESCRIPTION
I admit we can't recommend CL21[1].

I'd still like a batteries-included CL package to appear though.

On a positive note, as a beginner, I would have many more friendly libraries at my disposal (than when I was looking at CL21): generic-cl, access, rutils (now with documentation), and many smaller ones.

[1] (even though it still works in my project©…)