### PR TITLE
add Plausible analytics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,5 +73,8 @@
         }
       }
     </script>
+
+    <script async defer data-domain="lispcookbook.github.io/cl-cookbook" src="https://plausible.io/js/plausible.js"></script>
+
   </body>
 </html>


### PR DESCRIPTION
Hello,

I am curious to see some stat counters. What about you?
I propose to plug Plausible in. It's free software, privacy focused (RGPD compliant), also 

> Made and hosted in the EU
> 100% self-funded and independent

https://plausible.io

I just bought their hosting for one year. 

I will be able to generate a public link to share with you.

---

> Even though the purpose of Plausible Analytics is to track the usage of a website, this can still be done without collecting any personal data or personally identifiable information (PII), without using cookies and while respecting the privacy of your website visitors.

> By using Plausible Analytics, all the site measurement is carried out absolutely anonymously. Cookies are not set and no personal data is collected. All data is in aggregate only. The website owner gets some actionable data to help them learn and improve, while the visitor keeps having a nice and enjoyable experience.