### PR TITLE
Updates for 404 / deadlinks

### DIFF
--- a/arrays.md
+++ b/arrays.md
@@ -72,7 +72,7 @@ are given on the [github web pages](https://github.com/rigetticomputing/magicl).
 Low-level routines wrap foreign functions, so have the Fortran names
 e.g `magicl.lapack-cffi::%zgetrf`. Higher-level interfaces to some of
 these functions also exist, see the
-[source code](https://github.com/rigetti/magicl/blob/master/src/high-level/high-level.lisp).
+[source directory](https://github.com/rigetti/magicl/blob/master/src/high-level/) and [documentation](https://github.com/quil-lang/magicl/blob/master/doc/high-level.md).
 
 Taking this further, domain specific languages have been built on Common
 Lisp, which can be used for numerical calculations with arrays.

--- a/data-structures.md
+++ b/data-structures.md
@@ -18,7 +18,7 @@ also have many more details:
 Don't miss the appendix and when you need more data structures, have a
 look at the
 [awesome-cl](https://github.com/CodyReichert/awesome-cl#data-structures)
-list and [Quickdocs](http://quickdocs.org/search?q=data+structure).
+list and [Quickdocs](https://quickdocs.org/-/search?q=data%20structure).
 
 ## Lists
 

--- a/process.md
+++ b/process.md
@@ -2320,8 +2320,7 @@ library. This post barely scratches the surface on those. However, the
 general flow of operation is amply demonstrated here, and for further
 reading, you may find the following resources useful:
 
-- [The lparallel API docs hosted on Quickdoc](http://quickdocs.org/lparallel/api#package-LPARALLEL)
-- [The official homepage of the lparallel library](https://lparallel.org/)
+- [The official homepage of the lparallel library, including documentation](https://lparallel.org/)
 - [The Common Lisp Hyperspec](https://www.lispworks.com/documentation/HyperSpec/Front/), and, of course
 - Your Common Lisp implementation’s
   manual. [For SBCL, here is a link to the official manual](http://www.sbcl.org/manual/)

--- a/testing.md
+++ b/testing.md
@@ -396,7 +396,7 @@ build:
 ~~~
 
 Here we defined two `stages` (see
-[environments](https://docs.gitlab.com/ce/ci/environments.html)),
+[environments](https://docs.gitlab.com/ee/ci/environments/)),
 "test" and "build", defined to run one after another. A "build" stage
 will start only if the "test" one succeeds.
 

--- a/web-scraping.md
+++ b/web-scraping.md
@@ -333,4 +333,4 @@ More helpful libraries:
   network, parallelism and concurrency libraries to see on the
   [awesome-cl](https://github.com/CodyReichert/awesome-cl) list,
   [Cliki](http://www.cliki.net/) or
-  [Quickdocs](http://quickdocs.org/search?q=web).
+  [Quickdocs](https://quickdocs.org/-/search?q=web).


### PR DESCRIPTION
going through 404 links, #204, also commenting there with some ideas on tackling the issue long-term. Details in the 404 fixes often need discussing, so making small individual commits. 

Looks like rigetti  magicl high-level got broken down into smaller files and the original is gone / 404. I'm linking to the dir and doc for now. 

This is ready for merge.