### PR TITLE
Adds guix shell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The main goal is making the Cookbook more modern and more accessible in addition
 [contributing]: CONTRIBUTING.md
 [bundler-v2]: https://stackoverflow.com/questions/54087856/cant-find-gem-bundler-0-a-with-executable-bundle-gemgemnotfoundexceptio
 
+## Using GNU Guix
+
+To enter an environment in which all the required software dependencies are available, run `guix shell` in the project root directory.
+
 ## Support
 
 You can support the individuals that constantly improve the Cookbook. See the Github Sponsors icon. Thanks for them!


### PR DESCRIPTION
Hi, 

This adds instructions on how to load the manifest with [guix shell](https://guix.gnu.org/en/blog/2021/from-guix-environment-to-guix-shell/).

This would work on any GNU/Linus distro as long as you have GNU Guix installed.

Debian has GNU Guix officially packaged:

```
sudo apt install guix
```