### PR TITLE
Typo in getting-started.md

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -99,7 +99,7 @@ All implementations above can be installed on Windows.
 
 You can also try:
 
-* [ρEmacs](https://rho-emacs.sourceforge.io/), a preconfigured distribution of GNU Emacs specificalyl for Microsoft Windows. It ships with many CL implementations: CCL, SBCL, CLISP, ABCL and ECL, and also has components for other programming languages (Python, Racket, Java, C++…).
+* [ρEmacs](https://rho-emacs.sourceforge.io/), a preconfigured distribution of GNU Emacs specifically for Microsoft Windows. It ships with many CL implementations: CCL, SBCL, CLISP, ABCL and ECL, and also has components for other programming languages (Python, Racket, Java, C++…).
 * [Corman Lisp](https://github.com/sharplispers/cormanlisp), for Windows XP, Windows 2000, Windows ME or Windows NT. It is fully integrated with the Win32 API, and all the Windows API functions are readily available from Lisp.
 
 


### PR DESCRIPTION
Changed "specificalyl" to "specifically".