### PR TITLE
Format fixes, for converting to EPUB

### DIFF
--- a/arrays.md
+++ b/arrays.md
@@ -174,6 +174,7 @@ and [row-major-aref](http://clhs.lisp.se/Body/f_row_ma.htm#row-major-aref) funct
 The [aref](http://clhs.lisp.se/Body/f_aref.htm) function takes the same number of index arguments as the
 array has dimensions. Indexing is from 0 and row-major as in C, but
 not Fortran.
+
 ~~~lisp
 * (defparameter *a* #(1 2 3 4))
 *A*
@@ -201,6 +202,7 @@ The range of these indices can be found using
 
 or the rank of the array can be found, and then the size of each
 dimension queried:
+
 ~~~lisp
 * (array-rank *a*)
 1
@@ -214,7 +216,8 @@ dimension queried:
 3
 ~~~
 
-To loop over an array nested loops can be used, such as
+To loop over an array nested loops can be used, such as:
+
 ~~~lisp
 * (defparameter a #2A((1 2 3) (4 5 6)))
 A
@@ -269,10 +272,10 @@ A utility macro which does this for multiple dimensions is `nested-loop`:
            (unless (integerp dim) (error "Dimensions must be integers: ~S" dim)))
          (destructuring-bind ,(reverse dims-rev) ,dims ; Dimensions reversed so that innermost is last
            ,result)))))
-
 ~~~
 
-so that the contents of a 2D array can be printed using
+so that the contents of a 2D array can be printed using:
+
 ~~~lisp
 * (defparameter a #2A((1 2 3) (4 5 6)))
 A
@@ -343,6 +346,7 @@ ARR
 ~~~
 
 A matrix-matrix multiply operation can be implemented as:
+
 ~~~lisp
 (let ((A #2A((1 2) (3 4)))
       (B #2A((5 6) (7 8)))
@@ -354,6 +358,7 @@ A matrix-matrix multiply operation can be implemented as:
                        #i(result[i j] += A[i k] * B[k j]))))
       result)
 ~~~
+
 See the section below on linear algebra, for alternative
 matrix-multiply implementations.
 
@@ -421,6 +426,7 @@ fork](https://github.com/bendudson/array-operations) of array-operations, but
 not Quicklisp]
 
 This can be used as:
+
 ~~~lisp
 * (defparameter *a* #(1 2 3 4))
 *A*
@@ -441,7 +447,8 @@ B
 #(0.9092974 0.28224 -2.2704074 -3.8356972)
 ~~~
 
-and combined with `cmu-infix`
+and combined with `cmu-infix`:
+
 ~~~lisp
 * (vectorize (a b) #i(a * sin(b)) )
 #(0.9092974 0.28224 -2.2704074 -3.8356972)
@@ -482,6 +489,7 @@ B
 * y
 #(2.5d0 4.0d0 5.5d0)
 ~~~
+
 If the `y` array is complex, then this operation calls the complex
 number versions of these operators:
 
@@ -599,6 +607,7 @@ defined above, a macro which does not allocate can be defined as:
          ,result))))
 
 ~~~
+
 [Note: This macro is available in [this fork](https://github.com/bendudson/array-operations)
 of array-operations, but not Quicklisp]
 
@@ -660,6 +669,7 @@ column:
 * (lla:mm #2A((1 1 1) (2 2 2) (3 3 3))  #(2 3 4))
 #(9.0d0 18.0d0 27.0d0)
 ~~~
+
 which has performed the sum over `j` of `A[i j] * x[j]`
 
 #### Matrix-matrix multiply
@@ -668,6 +678,7 @@ which has performed the sum over `j` of `A[i j] * x[j]`
 * (lla:mm #2A((1 2 3) (1 2 3) (1 2 3))  #2A((2 3 4) (2 3 4) (2 3 4)))
 #2A((12.0d0 18.0d0 24.0d0) (12.0d0 18.0d0 24.0d0) (12.0d0 18.0d0 24.0d0))
 ~~~
+
 which summed over `j` in `A[i j] * B[j k]`
 
 Note that the type of the returned arrays are simple arrays,
@@ -695,6 +706,7 @@ To load "array-operations":
 * (aops:outer #'* #(1 2 3) #(2 3 4))
 #2A((2 3 4) (4 6 8) (6 9 12))
 ~~~
+
 which has created a new 2D array `A[i j] = B[i] * C[j]`. This `outer`
 function can take an arbitrary number of inputs, and inputs with
 multiple dimensions.
@@ -707,6 +719,7 @@ The direct inverse of a dense matrix can be calculated with `invert`
 * (lla:invert #2A((1 0 0) (0 1 0) (0 0 1)))
 #2A((1.0d0 0.0d0 -0.0d0) (0.0d0 1.0d0 -0.0d0) (0.0d0 0.0d0 1.0d0))
 ~~~
+
 e.g
 
 ~~~lisp

--- a/clos.md
+++ b/clos.md
@@ -663,19 +663,79 @@ might or might not be built using CLOS classes in any given
 implementation). However, 33 correspondences remain relating to
 "traditional" lisp types:
 
+<style>
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 5px;
+}
+th {
+  text-align: left;
+}
+</style>
 
-|`array`|`hash-table`|`readtable`|
-|`bit-vector`|`integer`|`real`|
-|`broadcast-stream`|`list`|`sequence`|
-|`character`|`logical-pathname`|`stream`|
-|`complex`|`null`|`string`|
-|`concatenated-stream`|`number`|`string-stream`|
-|`cons`|`package`|`symbol`|
-|`echo-stream`|`pathname`|`synonym-stream`|
-|`file-stream`|`random-state`|`t`|
-|`float`|`ratio`|`two-way-stream`|
-|`function`|`rational`|`vector`|
-
+<table>
+  <tbody>
+    <tr>
+      <td>array</td>
+      <td>hash-table</td>
+      <td>readtable</td>
+    </tr>
+    <tr>
+      <td>bit-vector</td>
+      <td>integer</td>
+      <td>real</td>
+    </tr>
+    <tr>
+      <td>broadcast-stream</td>
+      <td>list</td>
+      <td>sequence</td>
+    </tr>
+    <tr>
+      <td>character</td>
+      <td>logical-pathname</td>
+      <td>stream</td>
+    </tr>
+    <tr>
+      <td>complex</td>
+      <td>null</td>
+      <td>string</td>
+    </tr>
+    <tr>
+      <td>concatenated-stream</td>
+      <td>number</td>
+      <td>string-stream</td>
+    </tr>
+    <tr>
+      <td>cons</td>
+      <td>package</td>
+      <td>symbol</td>
+    </tr>
+    <tr>
+      <td>echo-stream</td>
+      <td>pathname</td>
+      <td>synonym-stream</td>
+    </tr>
+    <tr>
+      <td>file-stream</td>
+      <td>random-state</td>
+      <td>t</td>
+    </tr>
+    <tr>
+      <td>float</td>
+      <td>ratio</td>
+      <td>two-way-stream</td>
+    </tr>
+    <tr>
+      <td>function</td>
+      <td>rational</td>
+      <td>vector</td>
+    </tr>
+  </tbody>
+</table>
+<br>
 
 Note that not all "traditional" lisp types are included in this
 list. (Consider: `atom`, `fixnum`, `short-float`, and any type not
@@ -705,16 +765,15 @@ FOO
 ;; #<STRUCTURE-CLASS FOO 21DE8714>
 ~~~
 
-The metaclass of a `structure-object` is the class
-    `structure-class`. It is implementation-dependent whether
-    the metaclass of a "traditional" lisp object is
-    `standard-class`, `structure-class`, or
-    `built-in-class`. Restrictions:
+The metaclass of a `structure-object` is the class `structure-class`. It is implementation-dependent whether
+the metaclass of a "traditional" lisp object is `standard-class`, `structure-class`, or `built-in-class`.
+Restrictions:
 
-|`built-in-class`| May not use `make-instance`, may not use `slot-value`, may not use `defclass` to modify, may not create subclasses.|
-|`structure-class`| May not use `make-instance`, might work with `slot-value` (implementation-dependent). Use `defstruct` to subclass application structure types. Consequences of modifying an existing `structure-class` are undefined: full recompilation may be necessary.|
-|`standard-class`|None of these restrictions.|
+`built-in-class`: May not use `make-instance`, may not use `slot-value`, may not use `defclass` to modify, may not create subclasses.
 
+`structure-class`: May not use `make-instance`, might work with `slot-value` (implementation-dependent). Use `defstruct` to subclass application structure types. Consequences of modifying an existing `structure-class` are undefined: full recompilation may be necessary.
+
+`standard-class`: None of these restrictions.
 
 ### Introspection
 
@@ -801,7 +860,7 @@ expands to:
 ~~~
 
 It does much more and it is very flexible, however it is seldom used
-by the Common Lisp community: use at your own risks©.
+by the Common Lisp community: use at your own risk©.
 
 
 ## Methods

--- a/editor-support.md
+++ b/editor-support.md
@@ -156,9 +156,6 @@ So you probably want a shell alias:
 
     alias ilem='lem --eval "(lem-lisp-mode:start-lisp-repl t)"'
 
-<img src="assets/lem1.png" style="width: 800px" title="Lem's REPL" alt="Lem running in the terminal with the Lisp REPL full screen, showing a completion window."/>
-
-
 ## Sublime Text
 
 [Sublime Text](http://www.sublimetext.com/3) has now good support for

--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -107,7 +107,8 @@ must be loaded to add further functionalities. The default
 
 SLIME also has some nice extensions like
 [Helm-SLIME](https://github.com/emacs-helm/helm-slime) which features, among
-others
+others:
+
 - Fuzzy completion,
 - REPL and connection listing,
 - Fuzzy-search of the REPL history,

--- a/iteration.md
+++ b/iteration.md
@@ -814,7 +814,8 @@ The step must always be a positive number. If you want to count down, see above.
 
 #### Series
 
-with `:by`
+with `:by`:
+
 ~~~lisp
 (iterate ((i (scan-range :from 1 :upto 10 :by 2)))
   (print i))
@@ -1201,7 +1202,7 @@ But for alists, `scan-alist` is provided:
 
 `iterate` has some other things unique to it.
 
-If you are a newcomer in Lisp, it's perfectly OK to keep you this section for
+If you are a newcomer in Lisp, it's perfectly OK to keep this section for
 later. You could very well spend your career in Lisp without resorting
 to those features… although they might turn out useful one day.
 

--- a/lispworks.md
+++ b/lispworks.md
@@ -111,8 +111,8 @@ highlighting, Emacs-like keybindings (including the `M-x` extended
 command). The menus help the discovery.
 
 We personally found the editing experience a bit "raw". For example:
-- indention after a new line is not automatic, one has to press TAB
-again.
+
+- indention after a new line is not automatic, one has to press TAB again.
 - the auto-completion is not fuzzy.
 - there are no plugins similar to ~~Paredit~~ (there is a brand new (2021) [Paredit for LispWorks](https://github.com/g000001/lw-paredit)) or Lispy, nor a Vim layer.
 

--- a/make-cookbook.lisp
+++ b/make-cookbook.lisp
@@ -65,7 +65,7 @@
   "Transform markdown frontmatters to a title, etc."
   (format t "Edit the markdown...~&")
   (uiop:run-program (format nil "sed -i \"s/title:/# /g\" ~a" *full-markdown*))
-  (uiop:run-program (format nil "sed -i \"s/---/ /g\" ~a" *full-markdown*))
+  (uiop:run-program (format nil "sed -i \"/^---/s/---/ /g\" ~a" *full-markdown*))
   ;; Exclude regions that don't export correctly, like embedded videos.
   (uiop:run-program (format nil "sed -i \"/<\!-- epub-exclude-start -->/,/<\!-- epub-exclude-end -->/d\" ~a" *full-markdown*))
   )

--- a/numbers.md
+++ b/numbers.md
@@ -134,6 +134,7 @@ DOUBLE-FLOAT
 
 Note that unlike in some languages, appending a single decimal point
 to the end of a number does not make it a float:
+
 ~~~lisp
 * (type-of 10.)
 (INTEGER 0 4611686018427387903)
@@ -505,15 +506,61 @@ Common Lisp also provides many functions to perform bit-wise arithmetic
 operations. Some commonly used ones are listed below, together with their
 C/C++ equivalence.
 
-{:class="table table-bordered table-stripped"}
-| Common  Lisp     | C/C++       | Description                                      |
-|------------------|-------------|--------------------------------------------------|
-| `(logand a b c)` | `a & b & c` | Bit-wise AND of multiple operands                |
-| `(logior a b c)` | `a | b | c` | Bit-wise OR of multiple arguments                |
-| `(lognot a)`     | `~a`        | Bit-wise NOT of single operand                   |
-| `(logxor a b c)` | `a ^ b ^ c` | Bit-wise exclusive or (XOR) or multiple operands |
-| `(ash a 3)`      | `a << 3`    | Bit-wise left shift                              |
-| `(ash a -3)`     | `a >> 3`    | Bit-wise right shift                             |
+<style>
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 5px;
+}
+th {
+  text-align: left;
+}
+</style>
+
+<table>
+  <thead>
+    <tr>
+      <th>Common Lisp</th>
+      <th>C/C++</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>(logand a b c)</td>
+      <td>a & b & c</td>
+      <td>Bit-wise AND of multiple operands</td>
+    </tr>
+    <tr>
+      <td>(logior a b c)</td>
+      <td>a | b | c</td>
+      <td>Bit-wise OR of multiple operands</td>
+    </tr>
+    <tr>
+      <td>(lognot a)</td>
+      <td>~a</td>
+      <td>Bit-wise NOT of single operands</td>
+    </tr>
+    <tr>
+      <td>(logxor a b c)</td>
+      <td>a ^ b ^ c</td>
+      <td>Bit-wise exclusive or (XOR) of multiple operands</td>
+    </tr>
+    <tr>
+      <td>(ash a 3)</td>
+      <td>a << 3</td>
+      <td>Bit-wise left shift</td>
+    </tr>
+    <tr>
+      <td>(ash a -3)</td>
+      <td>a >> 3</td>
+      <td>Bit-wise right shift</td>
+    </tr>
+  </tbody>
+</table>
+<br>
 
 Negative numbers are treated as two's-complements. If you have forgotten this,
 please refer to the [Wiki page][twos-complements].

--- a/process.md
+++ b/process.md
@@ -2040,10 +2040,10 @@ through an example:
 #### lparallel:pmap: parallel version of map.
 
 Note that all the mapping functions (`lparallel:pmap`,
-**lparallel:pmapc**,`lparallel:pmapcar`, etc.) take two special keyword
-arguments
+**lparallel:pmapc**,`lparallel:pmapcar`, etc.) take two special keyword arguments:
+
 - `:size`, specifying the number of elements of the input
-sequence(s) to process, and
+sequence(s) to process.
 - `:parts` which specifies the number of parallel parts to divide the
 sequence(s) into.
 
@@ -2290,7 +2290,7 @@ them by age in non-decreasing order.
 
 To see how lparallel handles error handling (hint: with
 `lparallel:task-handler-bind`), please read
-[https://z0ltan.wordpress.com/2016/09/10/basic-concurrency-and-parallelism-in-common-lisp-part-4b-parallelism-using-lparallel-error-handling/](https://z0ltan.wordpress.com/2016/09/10/basic-concurrency-and-parallelism-in-common-lisp-part-4b-parallelism-using-lparallel-error-handling/).
+[lparallel-error-handling](https://z0ltan.wordpress.com/2016/09/10/basic-concurrency-and-parallelism-in-common-lisp-part-4b-parallelism-using-lparallel-error-handling/).
 
 
 ## Monitoring and controlling threads with Slime

--- a/scripting.md
+++ b/scripting.md
@@ -311,7 +311,7 @@ under 50ms.
 </div>
 
 
-Your SBCL must be built with core compression, see the documentation: [http://www.sbcl.org/manual/#Saving-a-Core-Image](http://www.sbcl.org/manual/#Saving-a-Core-Image)
+Your SBCL must be built with core compression, see the documentation: [Saving-a-Core-Image](http://www.sbcl.org/manual/#Saving-a-Core-Image)
 
 Is it the case ?
 

--- a/sockets.md
+++ b/sockets.md
@@ -23,6 +23,7 @@ that is specific to that connection. We can then use that connection to
 communicate with our client.
 
 So, what were the problems I faced due to my mistakes?
+
 Mistake 1 - My initial understanding was that `socket-accept` would return
 a stream object. NO.... It returns a socket object. In hindsight, its correct
 and my own mistake cost me time. So, if you want to write to the socket, you
@@ -97,7 +98,7 @@ Instead, you pass `nil` but you set `:local-host` and `:local-port` to the addre
 and port that you want to receive data on. This part took some time to
 figure out, because the documentation didn't cover it. Instead reading
 a bit of code from
-https://code.google.com/p/blackthorn-engine-3d/source/browse/src/examples/usocket/usocket.lisp helped a lot.
+[blackthorn-engine-3d](https://code.google.com/p/blackthorn-engine-3d/source/browse/src/examples/usocket/usocket.lisp) helped a lot.
 
 Also, since UDP is connectionless, anyone can send data to it at any
 time. So, we need to know which host/port did we get data from so
@@ -158,4 +159,4 @@ and `#(8 7 6 5 4 3 2 1)` on the second one.
 
 ## Credit
 
-This guide originally comes from https://gist.github.com/shortsightedsid/71cf34282dfae0dd2528
+This guide originally comes from [shortsightedsid](https://gist.github.com/shortsightedsid/71cf34282dfae0dd2528)

--- a/testing.md
+++ b/testing.md
@@ -162,7 +162,7 @@ The `test` macro provides a simple way to define a test with a name.
                          :error-if-not-exists t)))
 ~~~
 
-In the above code, 3 test were defined with 5 checks in total. Some checks were actually redundant for the sake of demonstration. You may put all the checks in one big test, or in multiple scenarios. It is up to you.
+In the above code, three tests were defined with 5 checks in total. Some checks were actually redundant for the sake of demonstration. You may put all the checks in one big test, or in multiple scenarios. It is up to you.
 
 The macro `test` is a convenience for `def-test` to define simple tests. You may read its docstring for a more complete introduction, for example to read about `:depends-on`.
 

--- a/type.md
+++ b/type.md
@@ -104,6 +104,7 @@ T
 
 The function [`subtypep`][subtypep] can be used to inspect if a type inherits
 from the another one. It returns 2 values:
+
 - `T, T` means first argument is sub-type of the second one.
 - `NIL, T` means first argument is *not* sub-type of the second one.
 - `NIL, NIL` means "not determined".


### PR DESCRIPTION
I have made a number of small changes to fix formatting errors when generating the EPUB.

I have verified that the changes work both in the EPUB, using the calibre ebook-viewer and emacs nov.el, and have checked the web pages generated by jekyll.