### PR TITLE
Fix internal links in EPUB.

### DIFF
--- a/clos.md
+++ b/clos.md
@@ -735,7 +735,9 @@ th {
     </tr>
   </tbody>
 </table>
+<!-- epub-exclude-start -->
 <br>
+<!-- epub-exclude-end -->
 
 Note that not all "traditional" lisp types are included in this
 list. (Consider: `atom`, `fixnum`, `short-float`, and any type not

--- a/databases.md
+++ b/databases.md
@@ -895,6 +895,8 @@ Use it like this:
 - [mito-attachment](https://github.com/fukamachi/mito-attachment)
 - [mito-auth](https://github.com/fukamachi/mito-auth)
 - [can](https://github.com/fukamachi/can/) a role-based access right control library
+<!-- epub-exclude-start -->
 - an advanced ["defmodel" macro](drafts/defmodel.lisp.html).
+<!-- epub-exclude-end -->
 
 <!-- # todo: Generating models for an existing DB -->

--- a/databases.md
+++ b/databases.md
@@ -587,7 +587,9 @@ You can compose your queries with regular Lisp code:
 <div class="info-box info">
 <strong>Note:</strong> if you didn't <code>use</code> SXQL, then write <code>(sxql:where …)</code> and <code>(sxql:order-by …)</code>.
 </div>
+<!-- epub-exclude-start -->
 <br>
+<!-- epub-exclude-end -->
 
 You can compose your queries further with the backquote syntax.
 

--- a/fix-epub-links.sed
+++ b/fix-epub-links.sed
@@ -1,0 +1,76 @@
+# sed script to change internal links in markdown file,
+# to links pandoc can use when generating EPUB from markdown.
+# Currently, the transformed links do not work in the web server,
+# so the script should change a file that is not used in the web server.
+# Usage:
+#   sed -i -f fix-epub-links.sed full.md
+# Note:
+#   The links with format like (#numbers), are there for a reason.
+#   The (#foo) format is used when the [foo] format is ambiguous.
+#
+# arrays.md
+s/\(\[\(Arrays and vectors\)\]\)(data-structures.html)/\1[\2]/
+# databases.md
+s/\(\[CLOS\]\)(clos.html)/\1[Fundamentals of CLOS]/
+s/\(\[clos\]\)(clos.html)/\1[Fundamentals of CLOS]/
+# data-structures.md
+s/\(\[pattern matching\]\)(pattern_matching.html)/\1[Pattern Matching]/
+s/\(\[strings\]\)(strings.html)/\1(#strings)/
+s/\(\[CLOS section\]\)(clos.html)/\1[Fundamentals of CLOS]/
+# debugging.md
+s/\(\[error handling\]\)(error_handling.html)/\1[Error and exception handling]/
+s/\(\[testing\]\)(testing.html)/\1[Testing the code]/
+# editor-support.md
+s/\(\["\(Using Emacs as an IDE\)"\]\)(emacs-ide.html)/\1[\2]/
+s/\(\[\(Using VSCode with Alive\)\]\)(vscode-alive.html)/\1[\2]/
+s/\(\[read our LispWorks review here\]\)(lispworks.html)/\1[LispWorks review]/
+# error_handling.md
+s/\(\[debugging section\]\)(debugging.html)/\1[Debugging]/
+# getting-started.md
+s/\(\[editor-support\]\)(editor-support.html)/\1[Editor support]/
+# index.md
+s/\(\[\(License\)\]\)(license.html)/\1[\2]/
+s/\(\[Getting started\]\)(getting-started.html)/\1[Getting started with Common Lisp]/
+s/\(\[\(Editor support\)\]\)(editor-support.html)/\1[\2]/
+s/\(\[\(Using Emacs as an IDE\)\]\)(emacs-ide.html)/\1[\2]/
+s/\(\[The LispWorks IDE\]\)(lispworks.html)/\1[LispWorks review]/
+s/\(\[Functions\]\)(functions.html)/\1(#functions)/
+s/\(\[Data Structures\]\)(data-structures.html)/\1[Data structures]/
+s/\(\[Strings\]\)(strings.html)/\1(#strings)/
+s/\(\[\(Regular Expressions\)\]\)(regexp.html)/\1[\2]/
+s/\(\[Numbers\]\)(numbers.html)/\1(#numbers)/
+s/\(\[Loops, iteration, mapping\]\)(iteration.html)/\1[Loop, iteration, mapping]/
+s/\(\[Multidimensional Arrays\]\)(arrays.html)/\1[Multidimensional arrays]/
+s/\(\[\(Dates and Times\)\]\)(dates_and_times.html)/\1[\2]/
+s/\(\[\(Pattern Matching\)\]\)(pattern_matching.html)/\1[\2]/
+s/\(\[\(Input\/Output\)\]\)(io.html)/\1[\2]/
+s/\(\[\(Files and Directories\)\]\)(files.html)/\1[\2]/
+s/\(\[Error and condition handling\]\)(error_handling.html)/\1[Error and exception handling]/
+s/\(\[\(Packages\)\]\)(packages.html)/\1[\2]/
+s/\(\[Macros and Backquote\]\)(macros.html)/\1[Macros]/
+s/\(\[CLOS (the Common Lisp Object System)\]\)(clos.html)/\1[Fundamentals of CLOS]/
+s/\(\[\(Type System\)\]\)(type.html)/\1[\2]/
+s/\(\[Sockets\]\)(sockets.html)/\1[TCP\/UDP programming with sockets]/
+s/\(\[\(Interfacing with your OS\)\]\)(os.html)/\1[\2]/
+s/\(\[\(Foreign Function Interfaces\)\]\)(ffi.html)/\1[\2]/
+s/\(\[\(Threads\)\]\)(process.html)/\1[\2]/
+s/\(\[\(Defining Systems\)\]\)(systems.html)/\1[\2]/
+s/\(\[\(Using the Win32 API\)\]\)(win32.html)/\1[\2]/
+s/\(\[\(Debugging\)\]\)(debugging.html)/\1[\2]/
+s/\(\[Performance Tuning\]\)(performance.html)/\1[Performance Tuning and Tips]/
+s/\(\[Scripting. Building executables\]\)(scripting.html)/\1[Scripting. Command line arguments. Executables.]/
+s/\(\[Testing and Continuous Integration\]\)(testing.html)/\1[Testing the code]/
+s/\(\[Databases\]\)(databases.html)/\1[Database Access and Persistence]/
+s/\(\[GUI programming\]\)(gui.html)/\1[GUI toolkits]/
+s/\(\[\(Web development\)\]\)(web.html)/\1[\2]/
+s/\(\[\(Web Scraping\)\]\)(web-scraping.html)/\1[\2]/
+s/\(\[\(WebSockets\)\]\)(websockets.html)/\1[\2]/
+s/\(\[\(Miscellaneous\)\]\)(misc.html)/\1[\2]/
+# iteration.md
+s/\(\[data-structures chapter\]\)(data-structures.html)/\1[Data structures]/
+# scripting.md
+s/\(\[error and condition handling\]\)(error_handling.html)/\1[Error and exception handling]/
+# strings.md
+s/\(\[regexp\]\)(regexp.html)/\1[Regular Expressions]/
+# web.md
+s/\(\[databases section\]\)(databases.html)/\1[Database Access and Persistence]/

--- a/fix-epub-links.sed
+++ b/fix-epub-links.sed
@@ -2,6 +2,15 @@
 # to links pandoc can use when generating EPUB from markdown.
 # Currently, the transformed links do not work in the web server,
 # so the script should change a file that is not used in the web server.
+# Examples of how links are transformed:
+# - In error_handling.md:
+#   "[debugging section](debugging.html)" to "[debugging section][Debugging]"
+#   It is expected that there is a section header with the title "Debugging".
+# - In data-structures.md:
+#   "[strings](strings.html)" to "[strings](#strings)"
+#   pandoc associates each section header with a unique key, here "strings".
+#   We specify the target header represented by "key", using the syntax (#key).
+#   This has to be used when the taget syntax [section header] is ambiguous.
 # Usage:
 #   sed -i -f fix-epub-links.sed full.md
 # Note:

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started
+title: Getting started with Common Lisp
 ---
 
 We'll begin with presenting easy steps to install a development environment and to start a new Common Lisp project.

--- a/index.md
+++ b/index.md
@@ -60,13 +60,17 @@ The Cookbook is also available in EPUB (and PDF) format.
 You can [download it directly in EPUB](https://github.com/LispCookbook/cl-cookbook/releases/download/2022-03-23/common-lisp-cookbook.epub) and [PDF](https://github.com/LispCookbook/cl-cookbook/releases/download/2022-03-23/common-lisp-cookbook.pdf), and you can **pay what you want** to further support its development:
 
 
+<!-- epub-exclude-start -->
 <br>
+<!-- epub-exclude-end -->
 
 <a style="font-size: 16px; background-color: #4CAF50; color: white; padding: 16px; cursor: pointer;" href="https://ko-fi.com/s/01fee22a32">
   Donate and download the EPUB version
 </a>
 
+<!-- epub-exclude-start -->
 <br>
+<!-- epub-exclude-end -->
 
 Thank you!
 

--- a/index.md
+++ b/index.md
@@ -41,7 +41,9 @@ The CL Cookbook aims to tackle all sort of topics, for the beginner as for the m
 * [Foreign Function Interfaces](ffi.html)
 * [Threads](process.html)
 * [Defining Systems](systems.html)
+<!-- epub-exclude-start -->
 * [Using the Win32 API](win32.html)
+<!-- epub-exclude-end -->
 * [Debugging](debugging.html)
 * [Performance Tuning](performance.html)
 * [Scripting. Building executables](scripting.html)
@@ -51,7 +53,9 @@ The CL Cookbook aims to tackle all sort of topics, for the beginner as for the m
 * [Web development](web.html)
 * [Web Scraping](web-scraping.html)
 * [WebSockets](websockets.html)
+<!-- epub-exclude-start -->
 * [Miscellaneous](misc.html)
+<!-- epub-exclude-end -->
 
 ## Download in EPUB
 
@@ -146,9 +150,11 @@ The pages here on Github are kept up to date. You can also download a
 [Github project page][gh].
 
 
+<!-- epub-exclude-start -->
 <div style="text-align: center">
     <img src="orly-cover.png" alt="Oh, really? book cover"/>
 </div>
+<!-- epub-exclude-end -->
 
 [cll]: news:comp.lang.lisp
 [perl]: http://www.oreilly.com/catalog/cookbook/

--- a/lispworks.md
+++ b/lispworks.md
@@ -1,5 +1,5 @@
 ---
-title: LispWorks
+title: LispWorks review
 ---
 
 [LispWorks](http://www.lispworks.com/) is a Common Lisp implementation that

--- a/make-cookbook.lisp
+++ b/make-cookbook.lisp
@@ -41,7 +41,7 @@
    "ffi.md"
    "process.md"
    "systems.md"
-   "win32.md"
+   ;; "win32.md" ; Excluded because: Out of date
    "debugging.md"
    "performance.md"
    "scripting.md"
@@ -51,7 +51,7 @@
    "web.md"
    "web-scraping.md"
    "websockets.md"
-   "misc.md"
+   ;; "misc.md" ; Excluded because: Lack of relevant content
    ;; "awesome-cl.md"
    "contributors.md"
    ))

--- a/make-cookbook.lisp
+++ b/make-cookbook.lisp
@@ -12,6 +12,8 @@
 
 (defparameter chapters
   (list
+   "index.md"
+   "license.md"
    "foreword.md"
    "getting-started.md"
    "editor-support.md"
@@ -36,9 +38,10 @@
    "type.md"
    "sockets.md"
    "os.md"
+   "ffi.md"
    "process.md"
    "systems.md"
-   ;; "win32.md"
+   "win32.md"
    "debugging.md"
    "performance.md"
    "scripting.md"
@@ -48,7 +51,7 @@
    "web.md"
    "web-scraping.md"
    "websockets.md"
-   ;; "misc.md"
+   "misc.md"
    ;; "awesome-cl.md"
    "contributors.md"
    ))
@@ -68,6 +71,8 @@
   (uiop:run-program (format nil "sed -i \"s/---/ /g\" ~a" *full-markdown*))
   ;; Exclude regions that don't export correctly, like embedded videos.
   (uiop:run-program (format nil "sed -i \"/<\!-- epub-exclude-start -->/,/<\!-- epub-exclude-end -->/d\" ~a" *full-markdown*))
+  ;; Make internal links work in the generated EPUB.
+  (uiop:run-program (format nil "sed -i -f fix-epub-links.sed ~a" *full-markdown*))
   )
 
 (defun to-epub ()

--- a/numbers.md
+++ b/numbers.md
@@ -560,7 +560,9 @@ th {
     </tr>
   </tbody>
 </table>
+<!-- epub-exclude-start -->
 <br>
+<!-- epub-exclude-end -->
 
 Negative numbers are treated as two's-complements. If you have forgotten this,
 please refer to the [Wiki page][twos-complements].

--- a/testing.md
+++ b/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Testing
+title: Testing the code
 ---
 
 So you want to easily test the code you're writing? The following


### PR DESCRIPTION
All internal links in EPUB should now work, except for a link in databases.md "an advanced defmodel macro", which refers to a file that does not yet seem to be part of the cookbook.
In make-cookbook.lisp I tentatively added/uncommented a few .md files, to include them in full.md.
I believe that including "index.md" improves the cookbook. I'm neutral about the other new files.
They were mostly included so that links referring to them would work.

The links are changed from internal markdown/html links to internal EPUB links by running the new sed script fix-epub-links.sed on full.md. This changes the links to a format that pandoc will recognize as a Heading Identifier.

The internal links have been checked in emacs nov.el and calibre ebook-viewer.