### PR TITLE
Fix instructions for local CLHS  lookup in Emacs

### DIFF
--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -551,12 +551,13 @@ Use `C-c M-m` to macroexpand a macro call
 
 ~~~lisp
 (ql:quickload "clhs")
+(clhs:install-clhs-use-local)
 ~~~
 
 Then add this to your Emacs configuration:
 
 ~~~lisp
-(load "~/.quicklisp/clhs-use-local.el" 'noerror)
+(load "~/quicklisp/clhs-use-local.el" 'noerror)
 ~~~
 
 ### Miscellaneous


### PR DESCRIPTION
The instructions missed the call to " (clhs:install-clhs-use-local)" and referenced the wrong directory for the .el file.