### PR TITLE
359: Reorder list of arguments to match function arguments

### DIFF
--- a/files.md
+++ b/files.md
@@ -622,8 +622,8 @@ Returns a list of pathnames:
 See `uiop/filesystem:collect-sub*directories`. It takes as arguments:
 
 - a `directory`
-- a `recursep` function
 - a `collectp` function
+- a `recursep` function
 - a `collector` function
 
 Given a directory, when `collectp` returns true with the directory,


### PR DESCRIPTION
I recently stumbled on #359 and thought I would fix it. Now the order of the arguments listed should match that of the function. If you think more examples would help clarify this for future readers I would be happy to write a few. 