### PR TITLE
Improve Emacs instructions, point users to an emacs quickstart.

### DIFF
--- a/editor-support.md
+++ b/editor-support.md
@@ -29,6 +29,7 @@ Since SLIME is heavily modular and the defaults only do the bare minimum (not
 even the SLIME REPL), you might want to enable more features with
 
 ~~~lisp
+(require 'slime)
 (slime-setup '(slime-fancy slime-quicklisp slime-asdf))
 ~~~
 
@@ -41,6 +42,7 @@ Now you can run SLIME with `M-x slime` and/or `M-x slime-connect`.
 See also:
 
 * [https://wikemacs.org/wiki/SLIME](https://wikemacs.org/wiki/SLIME) - configuration examples and extensions.
+* [https://github.com/susam/emacs4cl](https://github.com/susam/emacs4cl) - a minimal Emacs configuration to get new users up and running quickly, *with* a tutorial.
 
 
 ### Using Emacs as an IDE

--- a/os.md
+++ b/os.md
@@ -51,6 +51,8 @@ NIL
 
 You should also note that some of these implementations also provide the ability to _set_ these variables. These include ECL (`si:setenv`) and AllegroCL, LispWorks, and CLISP where you can use the functions from above together with [`setf`](http://www.lispworks.com/documentation/HyperSpec/Body/m_setf_.htm). This feature might be important if you want to start subprocesses from your Lisp environment.
 
+To set an envionmental variable, you can `setf` with `(uiop:getenv "lisp")` in a implementation-independent way.
+
 Also note that the
 [Osicat](https://www.common-lisp.net/project/osicat/manual/osicat.html#Environment)
 library has the method `(environment-variable "name")`, on POSIX-like


### PR DESCRIPTION
I've used emacs for more than a decade, but I found this quickstart to be the best I've seen in a long time and it worked flawlessly for me.

Also helps with https://github.com/LispCookbook/cl-cookbook/issues/522