### PR TITLE
Added Dockerfile for running Jekyll

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.5
+
+COPY . /cl-cookbook
+WORKDIR /cl-cookbook
+
+RUN gem install bundler -v 2.1.2
+# This spawns warnings..., let's ignore them using || true trick
+RUN bundle install || true 
+
+EXPOSE 4000
+
+CMD ["bundle", "exec", "jekyll", "serve", "--host=0.0.0.0", "--incremental"]
+
+# HOWTO RUN
+# docker build -t cl-cookbook .
+# docker run -p 4000:4000 -v $(pwd):/cl-cookbook cl-cookbook
+

--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ You can start by having a look at the [style guide](STYLEGUIDE.md).
 
 When adding new content, please ensure it renders properly.
 
-There are two ways to do this:
+There are three ways to do this:
+
+### Install Jekyll system-wide
 
 The first option is to install [Jekyll][jekyll] globally and to run `jekyll serve` in a folder where this repository was checked out.
 
 Then open `http://127.0.0.1:4000/cl-cookbook/` (the last `/` is important).
+
+### Install system locally using Ruby gems
 
 Another option is to install the Jekyll version of this repository locally with Ruby gems. Since bundler 1.17.3 requires Ruby 2.5 that is rather old, it is recommended to install it using rbenv:
 
@@ -27,6 +31,16 @@ Another option is to install the Jekyll version of this repository locally with 
 4. Run gem install bundler -v `2.1.4` to install bundler.
 5. `cd` to the `cl-cookbook` directory and run `bundle install --path vendor/bundle` to install Jekyll locally.
 6. Run `bundle exec jekyll serve` to generate the site and host it.
+
+### Use a Docker container
+
+Since it can be a bit troublesome to install older versions of Ruby onto newer Linux-based systems, another option is to use `docker`.
+
+1. Build the container by executing `sudo docker build -t cl-cookbook .` in this directory.
+2. Run Jekyll inside the container `sudo docker run -p 4000:4000 -v $(pwd):/cl-cookbook cl-cookbook` from this directory.
+3. Open your web browser and navigate to `http://127.0.0.1:4000/cl-cookbook/`.
+
+This command will mount the current working directory into the container and incremental builds are actived so you will be able to see your latest changes without restarting or rebuilding the container.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Hi,

I had troubles installing older Ruby onto a newer Linux-based OS (Ubuntu 22.04 Jammy). I created a Docker container with Jekyll. I hope you can find it useful, too.

(Gem didn't list `bundler` version 2.1.4 as available for installation, therefore there is 2.1.2 in Dockerfile. It spawns a warning but wors just fine.)

Martin