### PR TITLE
make absolute link to equality.html relative

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -1050,7 +1050,7 @@ library (in Quicklisp) has the functions `hash-table-keys` and
 
 Use `equalp` to compare the equality of hash-tables, element by
 element. `equalp` is case-insensitive for strings. Read more in our
-[equality](/equality.html) section.
+[equality](equality.html) section.
 
 
 ### Testing for the Presence of a Key in a Hash Table


### PR DESCRIPTION
The link was broken on https://lispcookbook.github.io/cl-cookbook/data-structures.html#comparing-hash-tables