### PR TITLE
Add alt to Logo to Improve Web Accessibility and Link Name

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
     <h1 id="title-xs"><a href="{{ site.baseurl }}/">The Common Lisp Cookbook</a> &ndash; {{ page.title }}</h1>
     <div id="logo-container">
       <a href="{{ site.baseurl }}/">
-        <img id="logo" src="{{ site.baseurl }}/assets/cl-logo-blue.png"/>
+        <img id="logo" src="{{ site.baseurl }}/assets/cl-logo-blue.png" alt="Common Lisp Logo"/>
       </a>
 
       <div id="searchform-container">


### PR DESCRIPTION
Two issues existed: missing alt on the logo image and no discernible name for the link.
Both affected screen reader accessibility, so I added an alt to the logo.