### PR TITLE
Fix incorrect script attribute

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,7 +61,7 @@
       <div id="toc-btn">T<br>O<br>C</div>
     </div>
 
-    <script text="javascript">
+    <script type="text/javascript">
       HighlightLisp.highlight_auto({className: null});
     </script>
 


### PR DESCRIPTION
Replaced invalid `text="javascript"` with `type="text/javascript"` to follow HTML standards and ensure proper script execution.

Reference:
[MDN Web Docs - <script> tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)