### PR TITLE
error handling: show how handler-bind doesn't unwind the stack. invoke-debugger

### DIFF
--- a/emacs-ide.md
+++ b/emacs-ide.md
@@ -625,7 +625,7 @@ Just try it with `C-h` too!
 
 See also [Helpful](https://github.com/Wilfred/helpful), an alternative to the built-in Emacs help that provides much more contextual information.
 
-<img src="assets/emacs-helpful.png" style="height: 450px"/>
+<img src="assets/emacs-helpful.png" style="height: 450px" alt="The Emacs helpful package shows detailed information about a symbol."/>
 
 
 ### Built-in tutorial

--- a/web.md
+++ b/web.md
@@ -532,7 +532,7 @@ See the documentation: [https://edicl.github.io/hunchentoot/#conditions](https:/
 
 Clack users might make a good use of plugins, like the clack-errors middleware: [https://github.com/CodyReichert/awesome-cl#clack-plugins](https://github.com/CodyReichert/awesome-cl#clack-plugins).
 
-<img src="assets/clack-errors.png" width="800"/>
+<img src="assets/clack-errors.png" width="800" alt="The clack-errors plugin shows the error message, a legible backtrace and environment variables."/>
 
 ## Weblocks - solving the "JavaScript problem"©
 


### PR DESCRIPTION
again, something I wish I understood earlier and that I discovered the hard way (or by chance). I hadn't touched this page in years, so it was lacking.

Please proof read everyone!

This was explained for some years in my course, I "backport" the example to the Cookbook, hope you find it useful. This addition is also thanks to Ari, who made me realize the lack of the page, with whom I do 1-1 lisp meetings, and there are a few slots available ;)

time spent: 1h40 (and more before :p )