### PR TITLE
Fix typos in 4 files (occured x3, wether x1)

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -611,7 +611,7 @@ See also the [Slime-star](https://github.com/mmontone/slime-star) Emacs extensio
 
 [*break-on-signals*](https://cl-community-spec.github.io/pages/002abreak_002don_002dsignals_002a.html)
 can be specially helpful when you see that an error (or any condition)
-occured, but you didn't get the debugger, and you want to force the
+occurred, but you didn't get the debugger, and you want to force the
 debugger to open *just before* the error (or any condition) is
 signaled.
 

--- a/files.md
+++ b/files.md
@@ -94,7 +94,7 @@ NIL
 ~~~
 
 
-### Testing wether a file exists (beware of wildcard characters)
+### Testing whether a file exists (beware of wildcard characters)
 
 Use `probe-file` after `(make-pathname :name filename-with-wild-chars)` or `sb-ext:parse-native-namestring` on SBCL. Why?
 

--- a/scripting.md
+++ b/scripting.md
@@ -434,7 +434,7 @@ can do something like this:
            (format *error-output* "Aborting.~&")
            (clack:stop *server*)
            (uiop:quit)))
-    (error (c) (format t "Woops, an unknown error occured:~&~a~&" c))))
+    (error (c) (format t "Woops, an unknown error occurred:~&~a~&" c))))
 ~~~
 
 We used the `bordeaux-threads` library (`(ql:quickload

--- a/web.md
+++ b/web.md
@@ -920,7 +920,7 @@ We could use such commands:
                               (parse-integer
                                 (uiop:getenv "PROJECT_PORT"))))
   (error (c)
-    (format *error-output* "~&An error occured: ~a~&" c)
+    (format *error-output* "~&An error occurred: ~a~&" c)
     (uiop:quit 1)))
 ~~~
 


### PR DESCRIPTION
Fixes typos across 4 files:

- `debugging.md:614` `occured` -> `occurred` (prose)
- `scripting.md:437` `occured` -> `occurred` (in Lisp format string)
- `web.md:923` `occured` -> `occurred` (in Lisp format string)
- `files.md:97` `wether` -> `whether` (section heading)