### PR TITLE
Add an action to auto build the pdf/epub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Build and release the book pdf and epub
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Prepare the dev environment
+        run: |
+          sudo apt update
+          sudo apt install build-essential sbcl cl-quicklisp calibre
+          # install lisp library deps
+          yes '' | sbcl --non-interactive \
+            --eval '(load "/usr/share/common-lisp/source/quicklisp/quicklisp.lisp")' \
+            --eval '(quicklisp-quickstart:install)' \
+            --eval '(ql:add-to-init-file)' \
+            --eval '(ql:quickload "str")'
+          # install a newer pandoc
+          wget https://github.com/jgm/pandoc/releases/download/3.10.2/pandoc-3.10.2-1-amd64.deb
+          sudo apt install ./pandoc-3.10.2-1-amd64.deb
+
+      - name: Download and install Typst
+        run: |
+          wget -O- "https://github.com/typst/typst/releases/latest/download/typst-x86_64-unknown-linux-musl.tar.xz" \
+            | tar -xJ
+          cd typst-x86_64-unknown-linux-musl/
+          chmod +x typst
+          mv typst /usr/local/bin/typst
+          typst --version
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build pdf and epub
+        id: build
+        run: |
+          make epub+pdf
+          echo "date_str=$(date '+%Y-%m')" >> "$GITHUB_OUTPUT"
+          mv "common-lisp-cookbook.epub" \
+             "common-lisp-cookbook-$(date '+%Y-%m').epub"
+          mv "common-lisp-cookbook.pdf" \
+             "common-lisp-cookbook-$(date '+%Y-%m').pdf"
+
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            common-lisp-cookbook-${{ steps.build.outputs.date_str }}.pdf
+            common-lisp-cookbook-${{ steps.build.outputs.date_str }}.epub

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ sample-pdf: clean
 
 epub+pdf: epub
 	sbcl --load make-cookbook.lisp --eval '(to-pdf)' --eval '(uiop:quit)'
+
+check-release:
+	sbcl --noinform --non-interactive --load make-cookbook.lisp --eval '(check-release)' --eval '(uiop:quit)'

--- a/make-cookbook.lisp
+++ b/make-cookbook.lisp
@@ -166,3 +166,53 @@
 (defun generate ()
   (reset-target)
   (build-full-source))
+
+(defun check-release ()
+  ;; --- checking metadata.txt ---
+  (let* ((fname "metadata.txt")
+         (ctime (multiple-value-list (get-decoded-time)))
+         (cyear  (write-to-string (nth  5 ctime)))
+         (months (list "January" "February" "March"
+                       "April"   "May"      "June"
+                       "July"    "August"   "September"
+                       "October" "November" "December"))
+         (cmonth (nth (1- (nth 4 ctime)) months))
+         (f (uiop:read-file-string fname)))
+    (format t "~%---Checking ~A---~&" fname)
+    (unless
+        (ppcre:register-groups-bind
+         (month year)
+         ("rights: © (\\w+) (\\d{4})" f)
+         (unless (and (string= cmonth month)
+                      (string= cyear year))
+           (format t "Mismatched date string in '~A':~&  Expected: ~A ~A~&  Actual  : ~A ~A~&"
+                   fname cmonth cyear month year)
+           (uiop:quit 2))
+         t)
+      (format t "Malformed date string in '~A'~&" fname)
+      (uiop:quit 2)))
+
+  ;; --- checking contributors.md ---
+  (let* ((fname "contributors.md")
+         (s_str "The contributors on Github are:")
+         (e_str "(this list is sorted by number of commits)")
+         (f (uiop:read-file-string fname))
+         (target_str
+          (ppcre:scan-to-strings (format nil "(?s)~A(.*?)~A" s_str e_str) f))
+         (commiters_actual
+          (ppcre:all-matches-as-strings "(?m)^\\*\\ .*" target_str))
+         (commiters_expected
+          (remove ""
+                  (uiop:split-string
+                   (uiop:run-program
+                    "git shortlog -sn HEAD | cut -f 2 | sed s/^/'* '/g"
+                    :force-shell t :output :string)
+                   :separator '(#\Newline))
+                  :test #'string=))
+         (commiters_new (set-difference commiters_expected commiters_actual
+                                        :test #'equal)))
+    (format t "~&---Checking ~A ---~&" fname)
+    (unless (null commiters_new)
+      (format t "Missing committers in '~A':~&" fname)
+      (format t "~{~A~%~}~&" commiters_new)
+      (uiop:quit 2))))


### PR DESCRIPTION
This workflow builds and releases the pdf/epub outputs on each tagged commit.
Originally, I had it generate a draft release on each commit push and overwrite previous outputs since it would provide a pdf/epub that is in sync with the web version (like [this](https://github.com/pvonmoradi/cl-cookbook/releases)). 
This PR only does a release on each tag.